### PR TITLE
Add ability to customise the generated role name and binding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ bld/
 # Testing results
 coverage.json
 coverage.info
+/.vs

--- a/src/KubeOps/Operator/Commands/Generators/RbacGenerator.cs
+++ b/src/KubeOps/Operator/Commands/Generators/RbacGenerator.cs
@@ -69,7 +69,9 @@ namespace KubeOps.Operator.Commands.Generators
             return ExitCodes.Success;
         }
 
-        public static string GetRbacRole(Assembly? assembly) => assembly?.GetCustomAttribute<RbacRoleAttribute>()?.Prefix ?? "operator-role";
+        public static string GetRbacRole(Assembly? assembly) => 
+            assembly?.GetCustomAttribute<RbacRoleAttribute>()?.Prefix 
+            ?? OperatorGenerator.OperatorName(assembly) + "-role";
 
         public static V1ClusterRoleBinding GenerateRoleBinding(string rbacRole)
         {

--- a/src/KubeOps/Operator/Commands/Generators/RbacGenerator.cs
+++ b/src/KubeOps/Operator/Commands/Generators/RbacGenerator.cs
@@ -25,35 +25,30 @@ namespace KubeOps.Operator.Commands.Generators
 
         public async Task<int> OnExecuteAsync(CommandLineApplication app)
         {
-            var role = _serializer.Serialize(GenerateManagerRbac(), Format);
-            var roleBinding = _serializer.Serialize(new V1ClusterRoleBinding
-            {
-                ApiVersion = $"{V1ClusterRoleBinding.KubeGroup}/{V1ClusterRoleBinding.KubeApiVersion}",
-                Kind = V1ClusterRoleBinding.KubeKind,
-                Metadata = new V1ObjectMeta {Name = "operator-role-binding"},
-                RoleRef = new V1RoleRef(V1ClusterRole.KubeGroup, V1ClusterRole.KubeKind, "operator-role"),
-                Subjects = new List<V1Subject>
-                {
-                    new V1Subject(V1ServiceAccount.KubeKind, "default", namespaceProperty: "system")
-                }
-            }, Format);
+            var assembly = Assembly.GetEntryAssembly();
+            var rbacRole = GetRbacRole(assembly);
+
+            var role = _serializer.Serialize(GenerateManagerRbac(assembly, rbacRole), Format);
+            var roleBinding = _serializer.Serialize(GenerateRoleBinding(rbacRole), Format);
 
             if (!string.IsNullOrWhiteSpace(OutputPath))
             {
+
+
                 Directory.CreateDirectory(OutputPath);
                 await using var roleFile = File.Open(Path.Join(OutputPath,
-                    $"operator-role.{Format.ToString().ToLower()}"), FileMode.Create);
+                    $"{rbacRole}.{Format.ToString().ToLower()}"), FileMode.Create);
                 await roleFile.WriteAsync(Encoding.UTF8.GetBytes(role));
                 await using var bindingFile = File.Open(Path.Join(OutputPath,
-                    $"operator-role-binding.{Format.ToString().ToLower()}"), FileMode.Create);
+                    $"{rbacRole}-binding.{Format.ToString().ToLower()}"), FileMode.Create);
                 await bindingFile.WriteAsync(Encoding.UTF8.GetBytes(roleBinding));
 
                 var kustomize = new KustomizationConfig
                 {
                     Resources = new List<string>
                     {
-                        $"operator-role.{Format.ToString().ToLower()}",
-                        $"operator-role-binding.{Format.ToString().ToLower()}",
+                        $"{rbacRole}.{Format.ToString().ToLower()}",
+                        $"{rbacRole}-binding.{Format.ToString().ToLower()}",
                     },
                     CommonLabels = new Dictionary<string, string>
                     {
@@ -74,19 +69,36 @@ namespace KubeOps.Operator.Commands.Generators
             return ExitCodes.Success;
         }
 
-        public static V1ClusterRole GenerateManagerRbac()
+        public static string GetRbacRole(Assembly? assembly) => assembly?.GetCustomAttribute<RbacRoleAttribute>()?.Prefix ?? "operator-role";
+
+        public static V1ClusterRoleBinding GenerateRoleBinding(string rbacRole)
         {
-            var assembly = Assembly.GetEntryAssembly();
+            return new V1ClusterRoleBinding
+            {
+                ApiVersion = $"{V1ClusterRoleBinding.KubeGroup}/{V1ClusterRoleBinding.KubeApiVersion}",
+                Kind = V1ClusterRoleBinding.KubeKind,
+                Metadata = new V1ObjectMeta { Name = $"{rbacRole}-binding" },
+                RoleRef = new V1RoleRef(V1ClusterRole.KubeGroup, V1ClusterRole.KubeKind, rbacRole),
+                Subjects = new List<V1Subject>
+                {
+                    new V1Subject(V1ServiceAccount.KubeKind, "default", namespaceProperty: "system")
+                }
+            };
+        }
+
+        public static V1ClusterRole GenerateManagerRbac(Assembly? assembly, string rbacRole)
+        {
             if (assembly == null)
             {
                 throw new Exception("No Entry Assembly found.");
             }
+            
 
             return new V1ClusterRole(
                 null,
                 $"{V1ClusterRole.KubeGroup}/{V1ClusterRole.KubeApiVersion}",
                 V1ClusterRole.KubeKind,
-                new V1ObjectMeta {Name = "operator-role"},
+                new V1ObjectMeta { Name = rbacRole },
                 new List<V1PolicyRule>(
                     GetAttributes<EntityRbacAttribute>(assembly)
                         .SelectMany(a => a.CreateRbacPolicies())

--- a/src/KubeOps/Operator/Comparing/ReferenceEqualityComparer.cs
+++ b/src/KubeOps/Operator/Comparing/ReferenceEqualityComparer.cs
@@ -4,7 +4,7 @@ namespace KubeOps.Operator.Comparing
 {
     internal class ReferenceEqualityComparer : EqualityComparer<object>
     {
-        public override bool Equals(object x, object y) => ReferenceEquals(x, y);
+        public override bool Equals(object? x, object? y) => ReferenceEquals(x, y);
 
         public override int GetHashCode(object obj) => obj == null ? 0 : obj.GetHashCode();
     }

--- a/src/KubeOps/Operator/Entities/CustomEntityDefinition.cs
+++ b/src/KubeOps/Operator/Entities/CustomEntityDefinition.cs
@@ -1,4 +1,6 @@
-﻿namespace KubeOps.Operator.Entities
+﻿using System.Collections.Generic;
+
+namespace KubeOps.Operator.Entities
 {
     internal readonly struct CustomEntityDefinition
     {
@@ -16,6 +18,8 @@
 
         public readonly EntityScope Scope;
 
+        public readonly IList<string>? ShortNames;
+
         public CustomEntityDefinition(
             string kind,
             string listKind,
@@ -23,7 +27,8 @@
             string version,
             string singular,
             string plural,
-            EntityScope scope)
+            EntityScope scope,
+            IList<string>? shortNames = null)
         {
             Kind = kind;
             ListKind = listKind;
@@ -32,6 +37,7 @@
             Singular = singular;
             Plural = plural;
             Scope = scope;
+            ShortNames = shortNames;
         }
     }
 }

--- a/src/KubeOps/Operator/Entities/EntityScopeAttribute.cs
+++ b/src/KubeOps/Operator/Entities/EntityScopeAttribute.cs
@@ -12,4 +12,17 @@ namespace KubeOps.Operator.Entities
 
         public EntityScope Scope { get; set; }
     }
+
+    [AttributeUsage(AttributeTargets.Class, Inherited = false)]
+    public sealed class EntityShortNameAttribute : Attribute
+    {
+        public EntityShortNameAttribute(string shortName)
+        {
+            if (shortName.ToLowerInvariant() != shortName) 
+                throw new ArgumentOutOfRangeException(nameof(shortName), "The shortnames need to be all lowercase");
+            ShortName = shortName;
+        }
+
+        public string ShortName { get; }
+    }
 }

--- a/src/KubeOps/Operator/Entities/Extensions/CustomEntityDefinitionExtensions.cs
+++ b/src/KubeOps/Operator/Entities/Extensions/CustomEntityDefinitionExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Reflection;
 using k8s;
 using k8s.Models;
@@ -26,6 +27,9 @@ namespace KubeOps.Operator.Entities.Extensions
             var scopeAttribute = resourceType.GetCustomAttribute<EntityScopeAttribute>();
             var kind = string.IsNullOrWhiteSpace(attribute.Kind) ? resourceType.Name : attribute.Kind;
 
+            var shortNames = resourceType.GetCustomAttributes<EntityShortNameAttribute>()
+                .Select(a => a.ShortName).ToList();
+
             return new CustomEntityDefinition(
                 kind,
                 $"{kind}List",
@@ -33,7 +37,8 @@ namespace KubeOps.Operator.Entities.Extensions
                 attribute.ApiVersion,
                 kind.ToLower(),
                 string.IsNullOrWhiteSpace(attribute.PluralName) ? $"{kind.ToLower()}s" : attribute.PluralName,
-                scopeAttribute?.Scope ?? default);
+                scopeAttribute?.Scope ?? default,
+                shortNames);
         }
     }
 }

--- a/src/KubeOps/Operator/Entities/Extensions/EntityToCrdExtensions.cs
+++ b/src/KubeOps/Operator/Entities/Extensions/EntityToCrdExtensions.cs
@@ -48,6 +48,7 @@ namespace KubeOps.Operator.Entities.Extensions
                 ListKind = entityDefinition.ListKind,
                 Singular = entityDefinition.Singular,
                 Plural = entityDefinition.Plural,
+                ShortNames = entityDefinition.ShortNames
             };
             spec.Scope = entityDefinition.Scope.ToString();
 

--- a/src/KubeOps/Operator/Rbac/EntityRbacAttribute.cs
+++ b/src/KubeOps/Operator/Rbac/EntityRbacAttribute.cs
@@ -22,11 +22,17 @@ namespace KubeOps.Operator.Rbac
     /// This attribute controls the operator's role name, primarily for the generation of kubernetes yamls
     /// </summary>
     [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false)]
-    public class OperatorNameAttribute : Attribute
+    public class OperatorSpecAttribute : Attribute
     {
-        public OperatorNameAttribute(string name) => Name = name;
+        public OperatorSpecAttribute(string name) => Name = name;
 
         public string Name { get; }
+
+        /// <summary>
+        /// For custom container registries, like something.azurecr.io this will be prefixed on the image name for the generated deployment
+        /// </summary>
+        public string? ContainerRegistry { get; set; }
+        public string? ImagePullSecretName { get; set; }
     }
 
     /// <summary>

--- a/src/KubeOps/Operator/Rbac/EntityRbacAttribute.cs
+++ b/src/KubeOps/Operator/Rbac/EntityRbacAttribute.cs
@@ -16,6 +16,22 @@ namespace KubeOps.Operator.Rbac
         public RbacVerb Verbs { get; set; }
     }
 
+
+
+    /// <summary>
+    /// This attribute controls the operator's role name, primarily for the generation of kubernetes yamls
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false)]
+    public class OperatorNameAttribute : Attribute
+    {
+        public OperatorNameAttribute(string name) => Name = name;
+
+        public string Name { get; }
+    }
+
+    /// <summary>
+    /// This attribute controls the operator's role name
+    /// </summary>
     [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false)]
     public class RbacRoleAttribute : Attribute
     {

--- a/src/KubeOps/Operator/Rbac/EntityRbacAttribute.cs
+++ b/src/KubeOps/Operator/Rbac/EntityRbacAttribute.cs
@@ -15,4 +15,12 @@ namespace KubeOps.Operator.Rbac
 
         public RbacVerb Verbs { get; set; }
     }
+
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false)]
+    public class RbacRoleAttribute : Attribute
+    {
+        public RbacRoleAttribute(string prefix) => Prefix = prefix;
+
+        public string Prefix { get; }
+    }
 }

--- a/tests/KubeOps.Test/Operator/Entities/CrdGeneration.Test.cs
+++ b/tests/KubeOps.Test/Operator/Entities/CrdGeneration.Test.cs
@@ -28,6 +28,7 @@ namespace KubeOps.Test.Operator.Entities
             crd.Spec.Names.Singular.Should().Be(ced.Singular);
             crd.Spec.Names.Plural.Should().Be(ced.Plural);
             crd.Spec.Scope.Should().Be(ced.Scope.ToString());
+            crd.Spec.Names.ShortNames.Should().Equal(ced.ShortNames);
         }
 
         [Fact]

--- a/tests/KubeOps.Test/Operator/Entities/OperatorGeneration.Test.cs
+++ b/tests/KubeOps.Test/Operator/Entities/OperatorGeneration.Test.cs
@@ -1,0 +1,50 @@
+﻿using KubeOps.Operator.Commands.Generators;
+using KubeOps.Test.Operator.Entities.TestEntities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using Xunit;
+
+namespace KubeOps.Test.Operator.Entities
+{
+    public class OperatorGenerationTest
+    {
+        private readonly Assembly _testSpecAssembly = typeof(TestSpecEntity).Assembly;
+
+        [Fact]
+        public void Should_Get_OperatorName_From_Assembly()
+        {
+            var result = OperatorGenerator.OperatorName(_testSpecAssembly);
+
+            Assert.Equal("test-operator", result);
+        }
+
+        [Fact]
+        public void Should_Generate_Deployment_With_Name()
+        {
+            var result = OperatorGenerator.GenerateDeployment(_testSpecAssembly);
+
+            Assert.Equal("test-operator", result.Metadata.Name);
+        }
+
+
+        [Fact]
+        public void Should_Generate_Image_Name()
+        {
+            var result = OperatorGenerator.GenerateDeployment(_testSpecAssembly);
+
+            Assert.Equal("some.azurecr.io/test-operator", result.Spec.Template.Spec.Containers.First().Image);
+        }
+
+        [Fact]
+        public void Should_Generate_With_ImagePullSecretName()
+        {
+            var result = OperatorGenerator.GenerateDeployment(_testSpecAssembly);
+
+            Assert.Equal("test-secret-name", result.Spec.Template.Spec.ImagePullSecrets.First().Name);
+        }
+
+    }
+}

--- a/tests/KubeOps.Test/Operator/Entities/RbacGeneration.Test.cs
+++ b/tests/KubeOps.Test/Operator/Entities/RbacGeneration.Test.cs
@@ -1,0 +1,49 @@
+﻿using KubeOps.Operator.Commands.Generators;
+using KubeOps.Test.Operator.Entities.TestEntities;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+using Xunit;
+
+namespace KubeOps.Test.Operator.Entities
+{
+    public class RbacGenerationTest
+    {
+        private readonly Assembly _testSpecAssembly = typeof(TestSpecEntity).Assembly;
+
+        [Fact]
+        public void Should_Get_RbacRole_From_Assembly()
+        {
+            var result = RbacGenerator.GetRbacRole(_testSpecAssembly);
+
+            Assert.Equal("test-operator", result);
+        }
+
+        [Fact]
+        public void Should_Generate_Role_With_Name()
+        {
+            var result = RbacGenerator.GenerateManagerRbac(_testSpecAssembly, "test-operator");
+
+            Assert.Equal("test-operator", result.Metadata.Name);
+        }
+
+
+        [Fact]
+        public void Should_Generate_RoleBinding_With_Name()
+        {
+            var result = RbacGenerator.GenerateRoleBinding("test-operator");
+
+            Assert.Equal("test-operator-binding", result.Metadata.Name);
+        }
+
+        [Fact]
+        public void Should_Generate_RoleBinding_With_RoleReference()
+        {
+            var result = RbacGenerator.GenerateRoleBinding("test-operator");
+
+            Assert.Equal("test-operator", result.RoleRef.Name);
+        }
+
+    }
+}

--- a/tests/KubeOps.Test/Operator/Entities/RbacGeneration.Test.cs
+++ b/tests/KubeOps.Test/Operator/Entities/RbacGeneration.Test.cs
@@ -17,7 +17,7 @@ namespace KubeOps.Test.Operator.Entities
         {
             var result = RbacGenerator.GetRbacRole(_testSpecAssembly);
 
-            Assert.Equal("test-role", result);
+            Assert.Equal("test-operator-role", result);
         }
 
         [Fact]

--- a/tests/KubeOps.Test/Operator/Entities/RbacGeneration.Test.cs
+++ b/tests/KubeOps.Test/Operator/Entities/RbacGeneration.Test.cs
@@ -17,7 +17,7 @@ namespace KubeOps.Test.Operator.Entities
         {
             var result = RbacGenerator.GetRbacRole(_testSpecAssembly);
 
-            Assert.Equal("test-operator", result);
+            Assert.Equal("test-role", result);
         }
 
         [Fact]

--- a/tests/KubeOps.Test/Operator/Entities/TestEntities/TestSpecEntity.cs
+++ b/tests/KubeOps.Test/Operator/Entities/TestEntities/TestSpecEntity.cs
@@ -4,8 +4,7 @@ using KubeOps.Operator.Entities;
 using KubeOps.Operator.Entities.Annotations;
 using KubeOps.Operator.Rbac;
 
-//[assembly: RbacRole("test-operator")]
-[assembly: OperatorName("test")]
+[assembly: OperatorSpec("test-operator", ImagePullSecretName = "test-secret-name", ContainerRegistry = "some.azurecr.io")]
 
 namespace KubeOps.Test.Operator.Entities.TestEntities
 {
@@ -87,6 +86,7 @@ namespace KubeOps.Test.Operator.Entities.TestEntities
     }
 
     [KubernetesEntity(Group = "kubeops.test.dev", ApiVersion = "V1")]
+    [EntityShortName("t")]
     public class TestSpecEntity : CustomKubernetesEntity<TestSpecEntitySpec>
     {
     }

--- a/tests/KubeOps.Test/Operator/Entities/TestEntities/TestSpecEntity.cs
+++ b/tests/KubeOps.Test/Operator/Entities/TestEntities/TestSpecEntity.cs
@@ -2,9 +2,13 @@
 using k8s.Models;
 using KubeOps.Operator.Entities;
 using KubeOps.Operator.Entities.Annotations;
+using KubeOps.Operator.Rbac;
+
+[assembly: RbacRole("test-operator")]
 
 namespace KubeOps.Test.Operator.Entities.TestEntities
 {
+
     [Description("This is the Spec Class Description")]
     public class TestSpecEntitySpec
     {

--- a/tests/KubeOps.Test/Operator/Entities/TestEntities/TestSpecEntity.cs
+++ b/tests/KubeOps.Test/Operator/Entities/TestEntities/TestSpecEntity.cs
@@ -4,7 +4,8 @@ using KubeOps.Operator.Entities;
 using KubeOps.Operator.Entities.Annotations;
 using KubeOps.Operator.Rbac;
 
-[assembly: RbacRole("test-operator")]
+//[assembly: RbacRole("test-operator")]
+[assembly: OperatorName("test")]
 
 namespace KubeOps.Test.Operator.Entities.TestEntities
 {


### PR DESCRIPTION
This is a really powerful project. I am writing my first controller and I am really happy with how it works. I was hand crafting my yamls and will be working to incorporate some of the key changes that I would like to improve the generation such that I can match my local files.

This first change introduces a new RbacRoleAttribute that can be applied at the assembly level to specify the role prefix that you would like to use. This way if multiple operators are added to a cluster, there are no conflicts. I added some unit tests to confirm the generation outputs the expected values. Without this attribute the default and previously hard coded string of `"operator-role"` is used.