### PR TITLE
Expose web host so that controllers may create a HTTP API

### DIFF
--- a/src/KubeOps/Operator/KubernetesOperator.cs
+++ b/src/KubeOps/Operator/KubernetesOperator.cs
@@ -14,6 +14,7 @@ using KubeOps.Operator.Serialization;
 using KubeOps.Operator.Watcher;
 using KubeOps.Testing;
 using McMaster.Extensions.CommandLineUtils;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -95,6 +96,12 @@ namespace KubeOps.Operator
             JsonConvert.DefaultSettings = () => OperatorHost.Services.GetRequiredService<JsonSerializerSettings>();
 
             return app.ExecuteAsync(args);
+        }
+
+        public KubernetesOperator ConfigureWebHost(Action<IWebHostBuilder> builder)
+        {
+            Builder.ConfigureWebHostDefaults(builder);
+            return this;
         }
 
         public KubernetesOperator ConfigureServices(Action<IServiceCollection> configuration)

--- a/tests/KubeOps.TestOperator/Program.cs
+++ b/tests/KubeOps.TestOperator/Program.cs
@@ -1,9 +1,27 @@
-﻿using System.Threading.Tasks;
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using System.Threading.Tasks;
 
 namespace KubeOps.TestOperator
 {
     public static class Program
     {
-        public static Task<int> Main(string[] args) => new Operator().Run(args);
+        public static Task<int> Main(string[] args) => new Operator()
+            .ConfigureWebHost(host => host.UseStartup<Startup>())
+            .Run(args);
+    }
+
+    public class Startup
+    {
+        public void Configure(IApplicationBuilder builder)
+        {
+            builder.UseRouting();
+            builder.UseEndpoints(e => e.MapGet("status", async ctx =>
+            {
+                await ctx.Response.WriteAsync("hello world");
+            }));
+        }
     }
 }


### PR DESCRIPTION
There are two aspects to this PR. The first is it is very simple to expose a HTTP API on the controller via standard AspNetCore mechanisms. I modified the TestOperator to include a super simple API to verify this works. I would like to use this to be able to inspect the state of my operators and perhaps introduce metrics and overview things such that I could integrate into prometheus or a dashboard.

Without calling this should be the same behaviour as current.

This works, it listens on port 5000 by default and exposes a simple hello world page at http://localhost:5000/status

I first considered modifying what the KubernetesOperator was doing to be extension methods off IHostBuilder so we could use a standard pipeline setup, but then realised there are specific needs of the operator that trump the genericness of host building, even though there is significant overlap. Plus I didn't want to be too invasive with the changes.