### PR TITLE
Support arrays of complex types in CRD generation

### DIFF
--- a/tests/KubeOps.Test/Operator/Entities/CrdGeneration.Test.cs
+++ b/tests/KubeOps.Test/Operator/Entities/CrdGeneration.Test.cs
@@ -89,6 +89,22 @@ namespace KubeOps.Test.Operator.Entities
         }
 
         [Fact]
+        public void Should_Set_The_Correct_Complex_Array_Type()
+        {
+            var crd = _testSpecEntity.CreateCrd();
+            var specProperties = crd.Spec.Versions.First().Schema.OpenAPIV3Schema.Properties["spec"];
+
+            var complexItemsArray = specProperties.Properties["complexItems"];
+            complexItemsArray.Type.Should().Be("array");
+            (complexItemsArray.Items as V1JSONSchemaProps)?.Type?.Should().Be("object");
+            complexItemsArray.Nullable.Should().BeNull();
+            var subProps = (complexItemsArray.Items as V1JSONSchemaProps)!.Properties;
+
+            var subName = subProps["name"];
+            subName?.Type.Should().Be("string");
+        }
+
+        [Fact]
         public void Should_Set_Description_On_Class()
         {
             var crd = _testSpecEntity.CreateCrd();

--- a/tests/KubeOps.Test/TestEntities/TestSpecEntity.cs
+++ b/tests/KubeOps.Test/TestEntities/TestSpecEntity.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using k8s.Models;
 using KubeOps.Operator.Entities;
 using KubeOps.Operator.Entities.Annotations;
@@ -76,6 +77,8 @@ namespace KubeOps.Test.TestEntities
         [Required]
         public int Required { get; set; }
 
+        public IEnumerable<TestItem> ComplexItems { get; set; } = Enumerable.Empty<TestItem>();
+
         public IDictionary Dictionary { get; set; } = new Dictionary<string, string>();
 
         public IDictionary<string, string> GenericDictionary { get; set; } = new Dictionary<string, string>();
@@ -101,5 +104,12 @@ namespace KubeOps.Test.TestEntities
     [KubernetesEntity(Group = "kubeops.test.dev", ApiVersion = "V1")]
     public class TestSpecEntity : CustomKubernetesEntity<TestSpecEntitySpec>
     {
+    }
+
+    public class TestItem
+    {
+        public string Name { get; set; } = null!;
+        public string Item { get; set; } = null!;
+        public string Extra { get; set; } = null!;
     }
 }


### PR DESCRIPTION
The CRD schema can support arrays of complex entities in the configuration. This PR extends the CRD generation to support this scenario. I added the unit test covering this and it looks good there, and I haven't committed but successfully installed the testEntity with this patched in.
![image](https://user-images.githubusercontent.com/2775804/93868690-2b892880-fd0e-11ea-9255-2debc2bba1be.png)
