### PR TITLE
Add extensions for specifying additional assemblies to search for ressources/entities.

### DIFF
--- a/src/KubeOps/Operator/Builder/IOperatorBuilder.cs
+++ b/src/KubeOps/Operator/Builder/IOperatorBuilder.cs
@@ -1,4 +1,5 @@
-﻿using k8s;
+﻿using System.Reflection;
+using k8s;
 using KubeOps.Operator.Controller;
 using KubeOps.Operator.Finalizer;
 using Microsoft.Extensions.DependencyInjection;
@@ -66,5 +67,13 @@ namespace KubeOps.Operator.Builder
         /// <returns>The builder for chaining.</returns>
         IOperatorBuilder AddFinalizer<TFinalizer>()
             where TFinalizer : class, IResourceFinalizer;
+
+        /// <summary>
+        /// Adds an assembly to the resource search path. This allows the given Assembly to searched
+        /// for resources when generating CRDs or RBAC definitions.
+        /// </summary>
+        /// <param name="assembly">The assembly to add.</param>
+        /// <returns>The builder for chaining.</returns>
+        IOperatorBuilder AddResourceAssembly(Assembly assembly);
     }
 }

--- a/src/KubeOps/Operator/Builder/OperatorBuilder.cs
+++ b/src/KubeOps/Operator/Builder/OperatorBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Reflection;
 using DotnetKubernetesClient;
 using KubeOps.Operator.Caching;
 using KubeOps.Operator.Controller;
@@ -31,6 +32,8 @@ namespace KubeOps.Operator.Builder
         }
 
         public IServiceCollection Services { get; }
+        
+        private IResourceTypeService ResourceTypeService { get; set; }
 
         public IOperatorBuilder AddHealthCheck<THealthCheck>(string? name = default)
             where THealthCheck : class, IHealthCheck
@@ -80,6 +83,13 @@ namespace KubeOps.Operator.Builder
             where TFinalizer : class, IResourceFinalizer
         {
             Services.AddTransient(typeof(IResourceFinalizer), typeof(TFinalizer));
+
+            return this;
+        }
+
+        public IOperatorBuilder AddResourceAssembly(Assembly assembly)
+        {
+            ResourceTypeService.AddAssembly(assembly);
 
             return this;
         }
@@ -135,6 +145,16 @@ namespace KubeOps.Operator.Builder
             // Support for leader election via V1Leases.
             Services.AddHostedService<LeaderElector>();
             Services.AddSingleton<ILeaderElection, LeaderElection>();
+
+            var entryAssembly = Assembly.GetEntryAssembly();
+            if (entryAssembly == null)
+            {
+                throw new Exception("No Entry Assembly found.");
+            }
+
+            ResourceTypeService = new ResourceTypeService(entryAssembly, Assembly.GetExecutingAssembly());
+
+            Services.AddSingleton(ResourceTypeService);
 
             return this;
         }

--- a/src/KubeOps/Operator/Builder/OperatorBuilder.cs
+++ b/src/KubeOps/Operator/Builder/OperatorBuilder.cs
@@ -29,10 +29,18 @@ namespace KubeOps.Operator.Builder
         public OperatorBuilder(IServiceCollection services)
         {
             Services = services;
+
+            var entryAssembly = Assembly.GetEntryAssembly();
+            if (entryAssembly == null)
+            {
+                throw new Exception("No Entry Assembly found.");
+            }
+
+            ResourceTypeService = new ResourceTypeService(entryAssembly, Assembly.GetExecutingAssembly());
         }
 
         public IServiceCollection Services { get; }
-        
+
         private IResourceTypeService ResourceTypeService { get; set; }
 
         public IOperatorBuilder AddHealthCheck<THealthCheck>(string? name = default)
@@ -145,14 +153,6 @@ namespace KubeOps.Operator.Builder
             // Support for leader election via V1Leases.
             Services.AddHostedService<LeaderElector>();
             Services.AddSingleton<ILeaderElection, LeaderElection>();
-
-            var entryAssembly = Assembly.GetEntryAssembly();
-            if (entryAssembly == null)
-            {
-                throw new Exception("No Entry Assembly found.");
-            }
-
-            ResourceTypeService = new ResourceTypeService(entryAssembly, Assembly.GetExecutingAssembly());
 
             Services.AddSingleton(ResourceTypeService);
 

--- a/src/KubeOps/Operator/Commands/Generators/CrdGenerator.cs
+++ b/src/KubeOps/Operator/Commands/Generators/CrdGenerator.cs
@@ -32,9 +32,9 @@ namespace KubeOps.Operator.Commands.Generators
         [Option("--use-old-crds", Description = "Defines that the old crd definitions (V1Beta1) should be used.")]
         public bool UseOldCrds { get; set; }
 
-        public IEnumerable<V1CustomResourceDefinition> GenerateCrds()
+        public static IEnumerable<V1CustomResourceDefinition> GenerateCrds(IResourceTypeService resourceTypeService)
         {
-            var resourceTypes = _resourceTypeService.GetResourceTypesByAttribute<KubernetesEntityAttribute>();
+            var resourceTypes = resourceTypeService.GetResourceTypesByAttribute<KubernetesEntityAttribute>();
 
             return resourceTypes
                 .Where(type => !type.GetCustomAttributes<IgnoreEntityAttribute>().Any())
@@ -74,7 +74,7 @@ namespace KubeOps.Operator.Commands.Generators
 
         public async Task<int> OnExecuteAsync(CommandLineApplication app)
         {
-            var crds = GenerateCrds().ToList();
+            var crds = GenerateCrds(_resourceTypeService).ToList();
             if (!string.IsNullOrWhiteSpace(OutputPath))
             {
                 Directory.CreateDirectory(OutputPath);

--- a/src/KubeOps/Operator/Commands/Generators/RbacGenerator.cs
+++ b/src/KubeOps/Operator/Commands/Generators/RbacGenerator.cs
@@ -28,12 +28,12 @@ namespace KubeOps.Operator.Commands.Generators
             _resourceTypeService = resourceTypeService;
         }
 
-        public V1ClusterRole GenerateManagerRbac()
+        public static V1ClusterRole GenerateManagerRbac(IResourceTypeService resourceTypeService)
         {
-            var entityRbacPolicyRules = _resourceTypeService.GetResourceAttributes<EntityRbacAttribute>()
+            var entityRbacPolicyRules = resourceTypeService.GetResourceAttributes<EntityRbacAttribute>()
                 .SelectMany(attribute => attribute.CreateRbacPolicies());
 
-            var genericRbacPolicyRules = _resourceTypeService.GetResourceAttributes<GenericRbacAttribute>()
+            var genericRbacPolicyRules = resourceTypeService.GetResourceAttributes<GenericRbacAttribute>()
                 .Select(attribute => attribute.CreateRbacPolicy());
 
             return new V1ClusterRole(
@@ -46,7 +46,7 @@ namespace KubeOps.Operator.Commands.Generators
 
         public async Task<int> OnExecuteAsync(CommandLineApplication app)
         {
-            var role = _serializer.Serialize(GenerateManagerRbac(), Format);
+            var role = _serializer.Serialize(GenerateManagerRbac(_resourceTypeService), Format);
             var roleBinding = _serializer.Serialize(
                 new V1ClusterRoleBinding
                 {

--- a/src/KubeOps/Operator/Commands/Generators/RbacGenerator.cs
+++ b/src/KubeOps/Operator/Commands/Generators/RbacGenerator.cs
@@ -102,9 +102,5 @@ namespace KubeOps.Operator.Commands.Generators
 
             return ExitCodes.Success;
         }
-
-        private static IEnumerable<TAttribute> GetAttributes<TAttribute>(Assembly assembly)
-            where TAttribute : Attribute =>
-            assembly.GetTypes().SelectMany(t => t.GetCustomAttributes<TAttribute>(true)); // TODO Call IResourceTypeService
     }
 }

--- a/src/KubeOps/Operator/Commands/Generators/RbacGenerator.cs
+++ b/src/KubeOps/Operator/Commands/Generators/RbacGenerator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -9,6 +10,7 @@ using k8s.Models;
 using KubeOps.Operator.Entities.Kustomize;
 using KubeOps.Operator.Rbac;
 using KubeOps.Operator.Serialization;
+using KubeOps.Operator.Services;
 using McMaster.Extensions.CommandLineUtils;
 
 namespace KubeOps.Operator.Commands.Generators
@@ -18,29 +20,28 @@ namespace KubeOps.Operator.Commands.Generators
     {
         private readonly EntitySerializer _serializer;
 
-        public RbacGenerator(EntitySerializer serializer)
+        private readonly IResourceTypeService _resourceTypeService;
+
+        public RbacGenerator(EntitySerializer serializer, IResourceTypeService resourceTypeService)
         {
             _serializer = serializer;
+            _resourceTypeService = resourceTypeService;
         }
 
-        public static V1ClusterRole GenerateManagerRbac()
+        public V1ClusterRole GenerateManagerRbac()
         {
-            var assembly = Assembly.GetEntryAssembly();
-            if (assembly == null)
-            {
-                throw new Exception("No Entry Assembly found.");
-            }
+            var entityRbacPolicyRules = _resourceTypeService.GetResourceAttributes<EntityRbacAttribute>()
+                .SelectMany(attribute => attribute.CreateRbacPolicies());
+
+            var genericRbacPolicyRules = _resourceTypeService.GetResourceAttributes<GenericRbacAttribute>()
+                .Select(attribute => attribute.CreateRbacPolicy());
 
             return new V1ClusterRole(
                 null,
                 $"{V1ClusterRole.KubeGroup}/{V1ClusterRole.KubeApiVersion}",
                 V1ClusterRole.KubeKind,
                 new V1ObjectMeta { Name = "operator-role" },
-                new List<V1PolicyRule>(
-                    GetAttributes<EntityRbacAttribute>(assembly)
-                        .Concat(GetAttributes<EntityRbacAttribute>(Assembly.GetExecutingAssembly()))
-                        .SelectMany(a => a.CreateRbacPolicies())
-                        .Concat(GetAttributes<GenericRbacAttribute>(assembly).Select(a => a.CreateRbacPolicy()))));
+                new List<V1PolicyRule>(Enumerable.Concat(entityRbacPolicyRules, genericRbacPolicyRules)));
         }
 
         public async Task<int> OnExecuteAsync(CommandLineApplication app)
@@ -104,6 +105,6 @@ namespace KubeOps.Operator.Commands.Generators
 
         private static IEnumerable<TAttribute> GetAttributes<TAttribute>(Assembly assembly)
             where TAttribute : Attribute =>
-            assembly.GetTypes().SelectMany(t => t.GetCustomAttributes<TAttribute>(true));
+            assembly.GetTypes().SelectMany(t => t.GetCustomAttributes<TAttribute>(true)); // TODO Call IResourceTypeService
     }
 }

--- a/src/KubeOps/Operator/Commands/Management/Install.cs
+++ b/src/KubeOps/Operator/Commands/Management/Install.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using DotnetKubernetesClient;
 using k8s.Models;
 using KubeOps.Operator.Commands.Generators;
+using KubeOps.Operator.Services;
 using McMaster.Extensions.CommandLineUtils;
 using Microsoft.Rest;
 
@@ -19,15 +20,18 @@ namespace KubeOps.Operator.Commands.Management
     {
         private readonly IKubernetesClient _client;
 
-        public Install(IKubernetesClient client)
+        private readonly IResourceTypeService _resourceTypeService;
+
+        public Install(IKubernetesClient client, IResourceTypeService resourceTypeService)
         {
             _client = client;
+            _resourceTypeService = resourceTypeService;
         }
 
         public async Task<int> OnExecuteAsync(CommandLineApplication app)
         {
             var error = false;
-            var crds = CrdGenerator.GenerateCrds().ToList();
+            var crds = CrdGenerator.GenerateCrds(_resourceTypeService).ToList();
             await app.Out.WriteLineAsync($"Found {crds.Count} CRD's.");
             await app.Out.WriteLineAsync($@"Starting install into cluster with url ""{_client.ApiClient.BaseUri}"".");
 

--- a/src/KubeOps/Operator/Commands/Management/Uninstall.cs
+++ b/src/KubeOps/Operator/Commands/Management/Uninstall.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using DotnetKubernetesClient;
 using k8s.Models;
 using KubeOps.Operator.Commands.Generators;
+using KubeOps.Operator.Services;
 using McMaster.Extensions.CommandLineUtils;
 using Microsoft.Rest;
 
@@ -19,9 +20,12 @@ namespace KubeOps.Operator.Commands.Management
     {
         private readonly IKubernetesClient _client;
 
-        public Uninstall(IKubernetesClient client)
+        private readonly IResourceTypeService _resourceTypeService;
+
+        public Uninstall(IKubernetesClient client, IResourceTypeService resourceTypeService)
         {
             _client = client;
+            _resourceTypeService = resourceTypeService;
         }
 
         [Option(Description = "Do not ask the user if the uninstall should proceed.")]
@@ -30,7 +34,7 @@ namespace KubeOps.Operator.Commands.Management
         public async Task<int> OnExecuteAsync(CommandLineApplication app)
         {
             var error = false;
-            var crds = CrdGenerator.GenerateCrds().ToList();
+            var crds = CrdGenerator.GenerateCrds(_resourceTypeService).ToList();
             await app.Out.WriteLineAsync($"Found {crds.Count} CRD's.");
 
             if (!Force && !Prompt.GetYesNo("Should the uninstall proceed?", false, ConsoleColor.Red))

--- a/src/KubeOps/Operator/Services/IResourceTypeService.cs
+++ b/src/KubeOps/Operator/Services/IResourceTypeService.cs
@@ -6,11 +6,11 @@ using System.Threading.Tasks;
 
 namespace KubeOps.Operator.Services
 {
-    public interface IResourceTypeService
+    internal interface IResourceTypeService
     {
-        public void AddAssembly(Assembly assembly);
+        void AddAssembly(Assembly assembly);
 
-        public IEnumerable<Type> GetResourceTypesByAttribute<TAttribute>()
+        IEnumerable<Type> GetResourceTypesByAttribute<TAttribute>()
             where TAttribute : Attribute;
 
         IEnumerable<TAttribute> GetResourceAttributes<TAttribute>()

--- a/src/KubeOps/Operator/Services/IResourceTypeService.cs
+++ b/src/KubeOps/Operator/Services/IResourceTypeService.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace KubeOps.Operator.Services
+{
+    public interface IResourceTypeService
+    {
+        public void AddAssembly(Assembly assembly);
+
+        public IEnumerable<Type> GetResourceTypesByAttribute<TAttribute>()
+            where TAttribute : Attribute;
+
+        IEnumerable<TAttribute> GetResourceAttributes<TAttribute>()
+            where TAttribute : Attribute;
+    }
+}

--- a/src/KubeOps/Operator/Services/ResourceTypeService.cs
+++ b/src/KubeOps/Operator/Services/ResourceTypeService.cs
@@ -7,11 +7,11 @@ using System.Threading.Tasks;
 
 namespace KubeOps.Operator.Services
 {
-    public class ResourceTypeService : IResourceTypeService
+    internal class ResourceTypeService : IResourceTypeService
     {
         private readonly ICollection<Assembly> _assemblies;
 
-        public ResourceTypeService(params Assembly[] assemblies)
+        internal ResourceTypeService(params Assembly[] assemblies)
         {
             _assemblies = new HashSet<Assembly>(assemblies);
         }

--- a/src/KubeOps/Operator/Services/ResourceTypeService.cs
+++ b/src/KubeOps/Operator/Services/ResourceTypeService.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace KubeOps.Operator.Services
+{
+    public class ResourceTypeService : IResourceTypeService
+    {
+        private readonly ICollection<Assembly> _assemblies;
+
+        public ResourceTypeService(params Assembly[] assemblies)
+        {
+            _assemblies = new HashSet<Assembly>(assemblies);
+        }
+
+        public void AddAssembly(Assembly assembly)
+        {
+            _assemblies.Add(assembly);
+        }
+
+        public IEnumerable<Type> GetResourceTypesByAttribute<TAttribute>()
+            where TAttribute : Attribute =>
+            _assemblies.SelectMany(assembly => assembly.GetTypes())
+                .Where(type => type.GetCustomAttributes<TAttribute>().Any());
+
+        public IEnumerable<TAttribute> GetResourceAttributes<TAttribute>()
+            where TAttribute : Attribute =>
+            _assemblies.SelectMany(
+                    assembly => assembly.GetTypes())
+                .SelectMany(type => type.GetCustomAttributes<TAttribute>(true));
+    }
+}

--- a/tests/KubeOps.Test/KubeOps.Test.csproj
+++ b/tests/KubeOps.Test/KubeOps.Test.csproj
@@ -18,6 +18,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\src\KubeOps\KubeOps.csproj" />
+        <ProjectReference Include="..\KubeOps.TestOperator\KubeOps.TestOperator.csproj" />
     </ItemGroup>
 
 </Project>

--- a/tests/KubeOps.Test/Operator/Commands/Generators/CrdGenerator.Test.cs
+++ b/tests/KubeOps.Test/Operator/Commands/Generators/CrdGenerator.Test.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using FluentAssertions;
 using k8s.Models;
 using KubeOps.Operator.Commands.Generators;
+using KubeOps.Operator.Services;
 using Xunit;
 
 namespace KubeOps.Test.Operator.Commands.Generators
@@ -12,7 +13,7 @@ namespace KubeOps.Test.Operator.Commands.Generators
     public class CrdGeneratorTest
     {
         private readonly IList<V1CustomResourceDefinition> _crds =
-            CrdGenerator.GenerateCrds(Assembly.GetExecutingAssembly()).ToList();
+            CrdGenerator.GenerateCrds(new ResourceTypeService()).ToList();
 
         [Fact]
         public void Should_Generate_Correct_Number_Of_Crds()

--- a/tests/KubeOps.Test/Operator/Commands/Generators/CrdGenerator.Test.cs
+++ b/tests/KubeOps.Test/Operator/Commands/Generators/CrdGenerator.Test.cs
@@ -13,7 +13,7 @@ namespace KubeOps.Test.Operator.Commands.Generators
     public class CrdGeneratorTest
     {
         private readonly IList<V1CustomResourceDefinition> _crds =
-            CrdGenerator.GenerateCrds(new ResourceTypeService()).ToList();
+            CrdGenerator.GenerateCrds(new ResourceTypeService(Assembly.GetExecutingAssembly())).ToList();
 
         [Fact]
         public void Should_Generate_Correct_Number_Of_Crds()

--- a/tests/KubeOps.Test/Operator/Entities/CrdGeneration.Test.cs
+++ b/tests/KubeOps.Test/Operator/Entities/CrdGeneration.Test.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using FluentAssertions;
@@ -6,6 +7,7 @@ using k8s.Models;
 using KubeOps.Operator.Commands.Generators;
 using KubeOps.Operator.Entities.Extensions;
 using KubeOps.Operator.Errors;
+using KubeOps.Operator.Services;
 using KubeOps.Test.TestEntities;
 using Xunit;
 
@@ -240,7 +242,7 @@ namespace KubeOps.Test.Operator.Entities
         [Fact]
         public void Should_Ignore_Entity_With_Ignore_Attribute()
         {
-            var crds = CrdGenerator.GenerateCrds(Assembly.GetExecutingAssembly()).ToList();
+            var crds = CrdGenerator.GenerateCrds(new ResourceTypeService()).ToList();
             crds.Should().NotContain(crd => crd.Spec.Names.Kind == "TestIgnoredEntity");
             crds.Should().Contain(crd => crd.Spec.Names.Kind == "TestSpecEntity");
         }

--- a/tests/KubeOps.Test/Operator/Entities/CrdGeneration.Test.cs
+++ b/tests/KubeOps.Test/Operator/Entities/CrdGeneration.Test.cs
@@ -242,7 +242,7 @@ namespace KubeOps.Test.Operator.Entities
         [Fact]
         public void Should_Ignore_Entity_With_Ignore_Attribute()
         {
-            var crds = CrdGenerator.GenerateCrds(new ResourceTypeService()).ToList();
+            var crds = CrdGenerator.GenerateCrds(new ResourceTypeService(Assembly.GetExecutingAssembly())).ToList();
             crds.Should().NotContain(crd => crd.Spec.Names.Kind == "TestIgnoredEntity");
             crds.Should().Contain(crd => crd.Spec.Names.Kind == "TestSpecEntity");
         }

--- a/tests/KubeOps.Test/Operator/Services/ResourceTypeService.Test.cs
+++ b/tests/KubeOps.Test/Operator/Services/ResourceTypeService.Test.cs
@@ -1,0 +1,68 @@
+﻿using System.Linq;
+using System.Reflection;
+using FluentAssertions;
+using k8s.Models;
+using KubeOps.Operator.Entities.Annotations;
+using KubeOps.Operator.Services;
+using KubeOps.TestOperator.Entities;
+using Xunit;
+
+namespace KubeOps.Test.Operator.Services
+{
+    public class ResourceTypeServiceTest
+    {
+        private readonly IResourceTypeService _currentAssemblyResourceTypeService =
+            new ResourceTypeService(Assembly.GetExecutingAssembly());
+
+        private readonly IResourceTypeService _testAssembliesResourceTypeService =
+            new ResourceTypeService(Assembly.GetExecutingAssembly(), Assembly.GetAssembly(typeof(V1TestEntity))!);
+
+        [Fact]
+        public void Should_Return_Correct_Number_Of_KubernetesEntity_Types()
+        {
+            var currentAssemblyTypes =
+                _currentAssemblyResourceTypeService.GetResourceTypesByAttribute<KubernetesEntityAttribute>();
+            var testAssembliesTypes =
+                _testAssembliesResourceTypeService.GetResourceTypesByAttribute<KubernetesEntityAttribute>();
+
+            currentAssemblyTypes.Count().Should().Be(11);
+            testAssembliesTypes.Count().Should().Be(13);
+        }
+
+        [Fact]
+        public void Should_Return_Correct_Number_Of_IgnoreEntity_Types()
+        {
+            var currentAssemblyTypes =
+                _currentAssemblyResourceTypeService.GetResourceTypesByAttribute<IgnoreEntityAttribute>();
+            var testAssembliesTypes =
+                _testAssembliesResourceTypeService.GetResourceTypesByAttribute<IgnoreEntityAttribute>();
+
+            currentAssemblyTypes.Count().Should().Be(2);
+            testAssembliesTypes.Count().Should().Be(2);
+        }
+
+        [Fact]
+        public void Should_Return_Correct_Number_Of_KubernetesEntityAttribute_Instances()
+        {
+            var currentAssemblyAttributes =
+                _currentAssemblyResourceTypeService.GetResourceAttributes<KubernetesEntityAttribute>();
+            var testAssembliesAttributes =
+                _testAssembliesResourceTypeService.GetResourceAttributes<KubernetesEntityAttribute>();
+
+            currentAssemblyAttributes.Count().Should().Be(11);
+            testAssembliesAttributes.Count().Should().Be(13);
+        }
+
+        [Fact]
+        public void Should_Return_Correct_Number_Of_IgnoreEntityAttribute_Instances()
+        {
+            var currentAssemblyAttributes =
+                _currentAssemblyResourceTypeService.GetResourceAttributes<IgnoreEntityAttribute>();
+            var testAssembliesAttributes =
+                _testAssembliesResourceTypeService.GetResourceAttributes<IgnoreEntityAttribute>();
+
+            currentAssemblyAttributes.Count().Should().Be(2);
+            testAssembliesAttributes.Count().Should().Be(2);
+        }
+    }
+}


### PR DESCRIPTION
This should close #103. I pulled out assembly listing into a service with an extension to register additional assemblies, with the defaults being the entry and executing assemblies.

As a consequence of not wanting to pass the service instance around too many times, `GenerateCrds` and `GenerateManagerRbac` had their static modifier removed, but that can be worked around if it was needed there.

I don't easily have code built to run tests on this; hoping @Aivanovac can see if this will support his codebase as the requestor of the issue that spawned this.