### PR TITLE
feat(crd generation): Add additional printer columns.

### DIFF
--- a/src/KubeOps/Operator/Entities/Annotations/AdditionalPrinterColumnAttribute.cs
+++ b/src/KubeOps/Operator/Entities/Annotations/AdditionalPrinterColumnAttribute.cs
@@ -1,0 +1,32 @@
+﻿using System;
+
+namespace KubeOps.Operator.Entities.Annotations
+{
+    /// <summary>
+    /// Defines a property as an additional printer column.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    public class AdditionalPrinterColumnAttribute : Attribute
+    {
+        /// <summary>
+        /// The name of the column. Defaults to the property-name.
+        /// </summary>
+        public string? Name { get; set; }
+
+        /// <summary>
+        /// The priority of the additional printer column.
+        /// As documented in
+        /// <a href="https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#priority">https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#priority</a>
+        /// the following rules apply to priority:
+        /// <list type="bullet">
+        /// <item>
+        /// <description>Columns with priority `0` are shown in standard view</description>
+        /// </item>
+        /// <item>
+        /// <description>Columns with priority greater than `0` are shown only in wide view</description>
+        /// </item>
+        /// </list>
+        /// </summary>
+        public int Priority { get; set; }
+    }
+}

--- a/src/KubeOps/Operator/Entities/Annotations/DescriptionAttribute.cs
+++ b/src/KubeOps/Operator/Entities/Annotations/DescriptionAttribute.cs
@@ -2,6 +2,10 @@
 
 namespace KubeOps.Operator.Entities.Annotations
 {
+    /// <summary>
+    /// Defines a description for a property. This precedes the description found in a
+    /// XML documentation file.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Class)]
     public class DescriptionAttribute : Attribute
     {
@@ -10,6 +14,9 @@ namespace KubeOps.Operator.Entities.Annotations
             Description = description;
         }
 
+        /// <summary>
+        /// The given description for the property.
+        /// </summary>
         public string Description { get; }
     }
 }

--- a/src/KubeOps/Operator/Entities/Annotations/EmbeddedResource.cs
+++ b/src/KubeOps/Operator/Entities/Annotations/EmbeddedResource.cs
@@ -1,9 +1,0 @@
-﻿using System;
-
-namespace KubeOps.Operator.Entities.Annotations
-{
-    [AttributeUsage(AttributeTargets.Property)]
-    public class EmbeddedResourceAttribute : Attribute
-    {
-    }
-}

--- a/src/KubeOps/Operator/Entities/Annotations/EmbeddedResourceAttribute.cs
+++ b/src/KubeOps/Operator/Entities/Annotations/EmbeddedResourceAttribute.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using k8s.Models;
+
+namespace KubeOps.Operator.Entities.Annotations
+{
+    /// <summary>
+    /// Defines a property as an embedded resource.
+    /// This property can contain another kubernetes object
+    /// (e.g. a <see cref="V1ConfigMap"/> or a <see cref="V1Deployment"/>).
+    /// This implicitly sets the <see cref="PreserveUnknownFieldsAttribute"/>.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    public class EmbeddedResourceAttribute : Attribute
+    {
+    }
+}

--- a/src/KubeOps/Operator/Entities/Annotations/ExternalDocsAttribute.cs
+++ b/src/KubeOps/Operator/Entities/Annotations/ExternalDocsAttribute.cs
@@ -2,6 +2,9 @@
 
 namespace KubeOps.Operator.Entities.Annotations
 {
+    /// <summary>
+    /// Defines that the property has an external documentation.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Property)]
     public class ExternalDocsAttribute : Attribute
     {
@@ -11,8 +14,14 @@ namespace KubeOps.Operator.Entities.Annotations
             Url = url;
         }
 
+        /// <summary>
+        /// Additional description.
+        /// </summary>
         public string? Description { get; }
 
+        /// <summary>
+        /// Url where to find the documentation.
+        /// </summary>
         public string Url { get; }
     }
 }

--- a/src/KubeOps/Operator/Entities/Annotations/GenericAdditionalPrinterColumnAttribute.cs
+++ b/src/KubeOps/Operator/Entities/Annotations/GenericAdditionalPrinterColumnAttribute.cs
@@ -1,0 +1,133 @@
+﻿using System;
+using k8s.Models;
+
+namespace KubeOps.Operator.Entities.Annotations
+{
+    /// <summary>
+    /// Defines a generic additional printer column.
+    /// With this, other elements (such as Metadata.Name)
+    /// can be referenced. In contrast to the <see cref="AdditionalPrinterColumnAttribute"/>,
+    /// all needed information must be provided.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+    public class GenericAdditionalPrinterColumnAttribute : Attribute
+    {
+        /// <summary>
+        /// Create a generic additional printer column.
+        /// </summary>
+        /// <param name="jsonPath">JsonPath as in <see cref="JsonPath"/>.</param>
+        /// <param name="name">Name as in <see cref="Name"/>.</param>
+        /// <param name="type">Type as in <see cref="Type"/>.</param>
+        public GenericAdditionalPrinterColumnAttribute(string jsonPath, string name, string type)
+        {
+            JsonPath = jsonPath;
+            Name = name;
+            Type = type;
+        }
+
+        /// <summary>
+        /// The json path for the property inside the resource.
+        /// <example>.spec.replicas</example>
+        /// <example>.metadata.namespace</example>
+        /// <example>.metadata.creationTimestamp</example>
+        /// </summary>
+        public string JsonPath { get; }
+
+        /// <summary>
+        /// The name of the column.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// Description for the column.
+        /// </summary>
+        public string? Description { get; set; }
+
+        /// <summary>
+        /// The type of the column.
+        /// As documented in
+        /// <a href="https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#type">https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#type</a>.
+        /// The type field can be any of the following (from OpenAPI v3 data types):
+        /// <list type="bullet">
+        /// <item>
+        /// <description>`integer` - non-floating-point number</description>
+        /// </item>
+        /// <item>
+        /// <description>`number` - floating point number</description>
+        /// </item>
+        /// <item>
+        /// <description>`string` - strings</description>
+        /// </item>
+        /// <item>
+        /// <description>`boolean`- `true` or `false`</description>
+        /// </item>
+        /// <item>
+        /// <description>`date` - rendered differentially as time since this timestamp</description>
+        /// </item>
+        /// </list>
+        /// If the value inside a CustomResource does not match the type specified for the column, the value is omitted.
+        /// </summary>
+        public string Type { get; }
+
+        /// <summary>
+        /// The format of the column.
+        /// As documented in
+        /// <a href="https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#format">https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#format</a>.
+        /// The format field can be any of the following:
+        /// <list type="bullet">
+        /// <item>
+        /// <description>`int32`</description>
+        /// </item>
+        /// <item>
+        /// <description>`int64`</description>
+        /// </item>
+        /// <item>
+        /// <description>`float`</description>
+        /// </item>
+        /// <item>
+        /// <description>`double`</description>
+        /// </item>
+        /// <item>
+        /// <description>`byte`</description>
+        /// </item>
+        /// <item>
+        /// <description>`date`</description>
+        /// </item>
+        /// <item>
+        /// <description>`date-time`</description>
+        /// </item>
+        /// <item>
+        /// <description>`password`</description>
+        /// </item>
+        /// </list>
+        /// </summary>
+        public string? Format { get; set; }
+
+        /// <summary>
+        /// The priority of the additional printer column.
+        /// As documented in
+        /// <a href="https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#priority">https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#priority</a>
+        /// the following rules apply to priority:
+        /// <list type="bullet">
+        /// <item>
+        /// <description>Columns with priority `0` are shown in standard view</description>
+        /// </item>
+        /// <item>
+        /// <description>Columns with priority greater than `0` are shown only in wide view</description>
+        /// </item>
+        /// </list>
+        /// </summary>
+        public int Priority { get; set; }
+
+        internal V1CustomResourceColumnDefinition ToAdditionalPrinterColumn()
+            => new()
+            {
+                Name = Name,
+                Description = Description,
+                Format = Format,
+                Priority = Priority,
+                Type = Type,
+                JsonPath = JsonPath,
+            };
+    }
+}

--- a/src/KubeOps/Operator/Entities/Annotations/ItemsAttribute.cs
+++ b/src/KubeOps/Operator/Entities/Annotations/ItemsAttribute.cs
@@ -2,11 +2,22 @@
 
 namespace KubeOps.Operator.Entities.Annotations
 {
+    /// <summary>
+    /// Define minimum and maximum items count for an array property.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Property)]
     public class ItemsAttribute : Attribute
     {
+        /// <summary>
+        /// If not `-1`, defines the minimal item count for the property.
+        /// -1 is used as the "null" - value.
+        /// </summary>
         public long MinItems { get; set; } = -1;
 
+        /// <summary>
+        /// If not `-1`, defines the maximal item count for the property.
+        /// -1 is used as the "null" - value.
+        /// </summary>
         public long MaxItems { get; set; } = -1;
     }
 }

--- a/src/KubeOps/Operator/Entities/Annotations/LengthAttribute.cs
+++ b/src/KubeOps/Operator/Entities/Annotations/LengthAttribute.cs
@@ -2,11 +2,22 @@
 
 namespace KubeOps.Operator.Entities.Annotations
 {
+    /// <summary>
+    /// Defines length limits for properties.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Property)]
     public class LengthAttribute : Attribute
     {
-        public int MinLength { get; set; } = -1;
+        /// <summary>
+        /// If not `-1`, define the minimum length.
+        /// -1 is used as the "null" - value.
+        /// </summary>
+        public long MinLength { get; set; } = -1;
 
-        public int MaxLength { get; set; } = -1;
+        /// <summary>
+        /// If not `-1`, define the maximum length.
+        /// -1 is used as the "null" - value.
+        /// </summary>
+        public long MaxLength { get; set; } = -1;
     }
 }

--- a/src/KubeOps/Operator/Entities/Annotations/MultipleOfAttribute.cs
+++ b/src/KubeOps/Operator/Entities/Annotations/MultipleOfAttribute.cs
@@ -2,6 +2,9 @@
 
 namespace KubeOps.Operator.Entities.Annotations
 {
+    /// <summary>
+    /// Defines the factor that a numeric value must adhere to.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Property)]
     public class MultipleOfAttribute : Attribute
     {
@@ -10,6 +13,9 @@ namespace KubeOps.Operator.Entities.Annotations
             Value = value;
         }
 
+        /// <summary>
+        /// The property should be a multiple of this value.
+        /// </summary>
         public double Value { get; }
     }
 }

--- a/src/KubeOps/Operator/Entities/Annotations/PatternAttribute.cs
+++ b/src/KubeOps/Operator/Entities/Annotations/PatternAttribute.cs
@@ -2,6 +2,9 @@
 
 namespace KubeOps.Operator.Entities.Annotations
 {
+    /// <summary>
+    /// Define a regex validator for the property.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Property)]
     public class PatternAttribute : Attribute
     {
@@ -10,6 +13,9 @@ namespace KubeOps.Operator.Entities.Annotations
             RegexPattern = regexPattern;
         }
 
+        /// <summary>
+        /// The regex pattern to be used.
+        /// </summary>
         public string RegexPattern { get; }
     }
 }

--- a/src/KubeOps/Operator/Entities/Annotations/PreserveUnknownFieldsAttribute.cs
+++ b/src/KubeOps/Operator/Entities/Annotations/PreserveUnknownFieldsAttribute.cs
@@ -2,6 +2,10 @@
 
 namespace KubeOps.Operator.Entities.Annotations
 {
+    /// <summary>
+    /// Defines that a property should keep unknown fields
+    /// so that kubernetes does not purge additional structures.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Property)]
     public class PreserveUnknownFieldsAttribute : Attribute
     {

--- a/src/KubeOps/Operator/Entities/Annotations/RangeMaximum.cs
+++ b/src/KubeOps/Operator/Entities/Annotations/RangeMaximum.cs
@@ -2,11 +2,20 @@
 
 namespace KubeOps.Operator.Entities.Annotations
 {
+    /// <summary>
+    /// Defines a range maximum for a numeric property.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Property)]
     public class RangeMaximumAttribute : Attribute
     {
-        public double Maximum { get; set; } = -1;
+        /// <summary>
+        /// Maximum value to be set.
+        /// </summary>
+        public double Maximum { get; set; }
 
+        /// <summary>
+        /// Defines if the maximum value is included or excluded.
+        /// </summary>
         public bool ExclusiveMaximum { get; set; }
     }
 }

--- a/src/KubeOps/Operator/Entities/Annotations/RangeMinimum.cs
+++ b/src/KubeOps/Operator/Entities/Annotations/RangeMinimum.cs
@@ -2,11 +2,20 @@
 
 namespace KubeOps.Operator.Entities.Annotations
 {
+    /// <summary>
+    /// Defines a range minimum for a numeric property.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Property)]
     public class RangeMinimumAttribute : Attribute
     {
+        /// <summary>
+        /// Minimum value to be set.
+        /// </summary>
         public double Minimum { get; set; }
 
+        /// <summary>
+        /// Defines if the minimum value is included or excluded.
+        /// </summary>
         public bool ExclusiveMinimum { get; set; }
     }
 }

--- a/src/KubeOps/Operator/Entities/Annotations/RequiredAttribute.cs
+++ b/src/KubeOps/Operator/Entities/Annotations/RequiredAttribute.cs
@@ -2,6 +2,9 @@
 
 namespace KubeOps.Operator.Entities.Annotations
 {
+    /// <summary>
+    /// Defines a property of a specification as required.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Property)]
     public class RequiredAttribute : Attribute
     {

--- a/src/KubeOps/Operator/Entities/CustomKubernetesEntity.cs
+++ b/src/KubeOps/Operator/Entities/CustomKubernetesEntity.cs
@@ -8,6 +8,9 @@ namespace KubeOps.Operator.Entities
     /// </summary>
     public abstract class CustomKubernetesEntity : KubernetesObject, IKubernetesObject<V1ObjectMeta>
     {
+        /// <summary>
+        /// The metadata of the kubernetes object.
+        /// </summary>
         public V1ObjectMeta Metadata { get; set; } = new();
     }
 }

--- a/src/KubeOps/Operator/Entities/CustomKubernetesEntity{TSpec,TStatus}.cs
+++ b/src/KubeOps/Operator/Entities/CustomKubernetesEntity{TSpec,TStatus}.cs
@@ -14,6 +14,9 @@ namespace KubeOps.Operator.Entities
         where TSpec : new()
         where TStatus : new()
     {
+        /// <summary>
+        /// Status object for the entity.
+        /// </summary>
         public TStatus Status { get; set; } = new();
     }
 }

--- a/src/KubeOps/Operator/Entities/CustomKubernetesEntity{TSpec}.cs
+++ b/src/KubeOps/Operator/Entities/CustomKubernetesEntity{TSpec}.cs
@@ -10,6 +10,9 @@ namespace KubeOps.Operator.Entities
     public abstract class CustomKubernetesEntity<TSpec> : CustomKubernetesEntity, ISpec<TSpec>
         where TSpec : new()
     {
+        /// <summary>
+        /// Specification of the kubernetes object.
+        /// </summary>
         public TSpec Spec { get; set; } = new();
     }
 }

--- a/tests/KubeOps.Test/TestEntities/TestSpecEntity.cs
+++ b/tests/KubeOps.Test/TestEntities/TestSpecEntity.cs
@@ -15,14 +15,17 @@ namespace KubeOps.Test.TestEntities
 
         public string[]? NullableStringArray { get; set; }
 
+        [AdditionalPrinterColumn]
         public string NormalString { get; set; } = string.Empty;
 
         public string? NullableString { get; set; }
 
+        [AdditionalPrinterColumn(Priority = 1)]
         public int NormalInt { get; set; }
 
         public int? NullableInt { get; set; }
 
+        [AdditionalPrinterColumn(Name = "OtherName")]
         public long NormalLong { get; set; }
 
         public long? NullableLong { get; set; }
@@ -102,6 +105,8 @@ namespace KubeOps.Test.TestEntities
     }
 
     [KubernetesEntity(Group = "kubeops.test.dev", ApiVersion = "V1")]
+    [GenericAdditionalPrinterColumn(".metadata.namespace", "Namespace", "string")]
+    [GenericAdditionalPrinterColumn(".metadata.creationTimestamp", "Age", "date")]
     public class TestSpecEntity : CustomKubernetesEntity<TestSpecEntitySpec>
     {
     }

--- a/tests/KubeOps.TestOperator/Entities/V2TestEntity.cs
+++ b/tests/KubeOps.TestOperator/Entities/V2TestEntity.cs
@@ -1,5 +1,6 @@
 ﻿using k8s.Models;
 using KubeOps.Operator.Entities;
+using KubeOps.Operator.Entities.Annotations;
 
 namespace KubeOps.TestOperator.Entities
 {
@@ -10,6 +11,7 @@ namespace KubeOps.TestOperator.Entities
         /// </summary>
         public string Spec { get; set; } = string.Empty;
 
+        [AdditionalPrinterColumn]
         public string Username { get; set; } = string.Empty;
 
         public IntstrIntOrString StringOrInteger { get; set; } = 42;
@@ -21,6 +23,7 @@ namespace KubeOps.TestOperator.Entities
     }
 
     [KubernetesEntity(Group = "testing.dev", ApiVersion = "v2", Kind = "TestEntity")]
+    [GenericAdditionalPrinterColumn(".metadata.namespace", "Namespace", "string")]
     public class V2TestEntity : CustomKubernetesEntity<V2TestEntitySpec, V2TestEntityStatus>
     {
     }

--- a/tests/KubeOps.TestOperator/test.yaml
+++ b/tests/KubeOps.TestOperator/test.yaml
@@ -1,6 +1,8 @@
-﻿apiVersion: testing.dev/v1
+﻿apiVersion: testing.dev/v2
 kind: TestEntity
 metadata:
   name: my-test-entity
 spec:
   spec: string
+  username: userNaMe
+  stringOrInteger: 1337


### PR DESCRIPTION
This closes #60. An additional `[AdditionalPrinterColumn]`
adds the possibility to add a specific property as an
additional printer column. The additional
`[GenericAdditionalPrinterColumn]` adds the possibility
to add any spec path to the additional printer columns.

Additionally, documentation for the various
property and class attributes for entities was
added.

Signed-off-by: Christoph Bühler <christoph@smartive.ch>