### PR TITLE
feat(events): Add event support for resources and controllers.

### DIFF
--- a/docs/docs/events.md
+++ b/docs/docs/events.md
@@ -1,0 +1,101 @@
+﻿# Events
+
+Kubernetes knows "Events" which can be sort of attached to a resource
+(i.e. a Kubernetes object).
+
+To create and use events, inject the @"KubeOps.Operator.Events.IEventManager"
+into your controller. It is registered as a transient resource in the DI
+container.
+
+## IEventManager
+
+### Publish events
+
+The event manager allows you to either publish an event that you created
+by yourself, or helps you publish events with predefined data.
+
+If you want to use the helper:
+```c#
+// fetch from DI, or inject into your controller.
+IEventManager manager = services.GetRequiredService<IEventManager>;
+
+// Publish the event.
+// This creates an event and publishes it.
+// If the event was previously published, it is fetched
+// and the "count" number is increased. This essentially
+// creates an event-series.
+await manager.Publish(resource, "reason", "my fancy message");
+```
+
+If you want full control over the event:
+```c#
+// fetch from DI, or inject into your controller.
+IEventManager manager = services.GetRequiredService<IEventManager>;
+
+var @event = new Corev1Event
+    {
+        // ... fill out all fields.
+    }
+
+// Publish the event.
+// This essentially calls IKubernetesClient.Save.
+await manager.Publish(@event);
+```
+
+### Use publisher delegates
+
+If you don't want to call the
+@"KubeOps.Operator.Events.IEventManager.Publish(k8s.IKubernetesObject{k8s.Models.V1ObjectMeta},System.String,System.String,KubeOps.Operator.Events.EventType)"
+all the time with the same arguments, you can create delegates.
+
+There exist two different delegates:
+- @"KubeOps.Operator.Events.IEventManager.StaticPublisher": Predefined event
+  on a predefined resource.
+- @"KubeOps.Operator.Events.IEventManager.Publisher": Predefined event
+  on a variable resource.
+
+Both are created with their specific overload:
+- @"KubeOps.Operator.Events.IEventManager.CreatePublisher(k8s.IKubernetesObject{k8s.Models.V1ObjectMeta},System.String,System.String,KubeOps.Operator.Events.EventType)"
+- @"KubeOps.Operator.Events.IEventManager.CreatePublisher(System.String,System.String,KubeOps.Operator.Events.EventType)"
+
+To use the static publisher:
+```c#
+var publisher = manager.CreatePublisher(resource, "reason", "message");
+await publisher();
+
+// and later on:
+await publisher(); // again without specifying reason / message and so on.
+```
+
+To use the dynamic publisher:
+```c#
+var publisher = manager.CreatePublisher("reason", "message");
+await publisher(resource);
+
+// and later on:
+await publisher(resource); // again without specifying reason / message and so on.
+```
+
+The dynamic publisher can be used to predefine the event for your resources.
+
+As an example in a controller:
+```c#
+public class TestController : ResourceControllerBase<V1TestEntity>
+{
+    private readonly IEventManager.Publisher _publisher;
+
+    public TestController(IEventManager eventManager, IResourceServices<V1TestEntity> services)
+        : base(services)
+    {
+        _publisher = eventManager.CreatePublisher("reason", "my fancy message");
+    }
+
+    protected override async Task<TimeSpan?> Created(V1TestEntity resource)
+    {
+        // Here, the event is published with predefined strings
+        // but for a "variable" resource.
+        await _publisher(resource);
+        return await base.Created(resource);
+    }
+}
+```

--- a/docs/docs/toc.yml
+++ b/docs/docs/toc.yml
@@ -8,6 +8,8 @@
   href: entities.md
 - name: Controller
   href: controller.md
+- name: Events
+  href: events.md
 - name: Finalizer
   href: finalizer.md
 - name: Utilities

--- a/docs/docs/utilities.md
+++ b/docs/docs/utilities.md
@@ -35,3 +35,12 @@ to see which metrics are available.
 
 Of course you can also have a look at the used metrics classes to see the
 implementation: [Metrics Implementations](https://github.com/buehler/dotnet-operator-sdk/tree/master/src/KubeOps/Operator/DevOps).
+
+# Entity / Resource utils
+
+There are several method extensions that help with day to day resource
+handling. Head over to their documentation to see that they do:
+
+- @"KubeOps.Operator.Entities.Extensions.KubernetesObjectExtensions.MakeObjectReference(k8s.IKubernetesObject{k8s.Models.V1ObjectMeta})"
+- @"KubeOps.Operator.Entities.Extensions.KubernetesObjectExtensions.MakeOwnerReference(k8s.IKubernetesObject{k8s.Models.V1ObjectMeta})"
+- @"KubeOps.Operator.Entities.Extensions.KubernetesObjectExtensions.WithOwnerReference``1(``0,k8s.IKubernetesObject{k8s.Models.V1ObjectMeta})"

--- a/src/KubeOps/KubeOps.csproj
+++ b/src/KubeOps/KubeOps.csproj
@@ -32,6 +32,7 @@
         <PackageReference Include="Namotion.Reflection" Version="1.0.15" />
         <PackageReference Include="prometheus-net.AspNetCore" Version="4.1.1" />
         <PackageReference Include="prometheus-net.AspNetCore.HealthChecks" Version="4.1.1" />
+        <PackageReference Include="SimpleBase" Version="3.0.2" />
         <PackageReference Include="YamlDotNet" Version="9.1.4" />
     </ItemGroup>
 

--- a/src/KubeOps/Operator/Builder/OperatorBuilder.cs
+++ b/src/KubeOps/Operator/Builder/OperatorBuilder.cs
@@ -5,6 +5,7 @@ using DotnetKubernetesClient;
 using KubeOps.Operator.Caching;
 using KubeOps.Operator.Controller;
 using KubeOps.Operator.DevOps;
+using KubeOps.Operator.Events;
 using KubeOps.Operator.Finalizer;
 using KubeOps.Operator.Leadership;
 using KubeOps.Operator.Queue;
@@ -136,6 +137,7 @@ namespace KubeOps.Operator.Builder
             Services.AddTransient<EntitySerializer>();
 
             Services.AddTransient<IKubernetesClient, KubernetesClient>();
+            Services.AddTransient<IEventManager, EventManager>();
 
             Services.AddSingleton(typeof(IResourceCache<>), typeof(ResourceCache<>));
             Services.AddTransient(typeof(IResourceWatcher<>), typeof(ResourceWatcher<>));

--- a/src/KubeOps/Operator/Events/EventManager.cs
+++ b/src/KubeOps/Operator/Events/EventManager.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using DotnetKubernetesClient;
+using k8s;
+using k8s.Models;
+using KubeOps.Operator.Entities.Extensions;
+using Microsoft.Extensions.Logging;
+using SimpleBase;
+
+namespace KubeOps.Operator.Events
+{
+    internal class EventManager : IEventManager
+    {
+        private readonly IKubernetesClient _client;
+        private readonly OperatorSettings _settings;
+        private readonly ILogger<EventManager> _logger;
+
+        public EventManager(IKubernetesClient client, OperatorSettings settings, ILogger<EventManager> logger)
+        {
+            _client = client;
+            _settings = settings;
+            _logger = logger;
+        }
+
+        public async Task Publish(
+            IKubernetesObject<V1ObjectMeta> resource,
+            string reason,
+            string message,
+            EventType type = EventType.Normal)
+        {
+            _logger.LogTrace(
+                "Encoding event name with: {resourceName}.{resourceNamespace}.{reason}.{message}.{type}.",
+                resource.Name(),
+                resource.Namespace(),
+                reason,
+                message,
+                type);
+            var eventName =
+                Base32.Rfc4648.Encode(
+                    SHA512.HashData(
+                        Encoding.UTF8.GetBytes($"{resource.Name()}.{resource.Namespace()}.{reason}.{message}.{type}")));
+            _logger.LogTrace(@"Search or create event with name ""{name}"".", eventName);
+            var @event = await _client.Get<Corev1Event>(eventName, resource.Namespace()) ??
+                         new Corev1Event
+                         {
+                             Kind = Corev1Event.KubeKind,
+                             ApiVersion = $"{Corev1Event.KubeGroup}/{Corev1Event.KubeApiVersion}",
+                             Metadata = new V1ObjectMeta
+                             {
+                                 Name = eventName,
+                                 NamespaceProperty = resource.Namespace(),
+                                 Annotations = new Dictionary<string, string>
+                                 {
+                                     { "nameHash", "sha512" },
+                                     { "nameEncoding", "Base32 / RFC 4648" },
+                                 },
+                             },
+                             Type = type.ToString(),
+                             Reason = reason,
+                             Message = message,
+                             ReportingComponent = _settings.Name,
+                             ReportingInstance = Environment.MachineName,
+                             Source = new V1EventSource { Component = _settings.Name },
+                             InvolvedObject = resource.MakeObjectReference(),
+                             FirstTimestamp = DateTime.UtcNow,
+                             LastTimestamp = DateTime.UtcNow,
+                             Count = 0,
+                         };
+
+            @event.Count++;
+            @event.LastTimestamp = DateTime.UtcNow;
+            _logger.LogTrace(
+                "Save event with new count {count} and last timestamp {timestamp}",
+                @event.Count,
+                @event.LastTimestamp);
+
+            await _client.Save(@event);
+            _logger.LogDebug(@"Created or updated event with name ""{name}"".", eventName);
+        }
+
+        public Task Publish(Corev1Event @event)
+            => _client.Save(@event);
+
+        public IEventManager.Publisher CreatePublisher(string reason, string message, EventType type = EventType.Normal)
+            => resource => Publish(resource, reason, message, type);
+
+        public IEventManager.StaticPublisher CreatePublisher(
+            IKubernetesObject<V1ObjectMeta> resource,
+            string reason,
+            string message,
+            EventType type = EventType.Normal)
+            => () => Publish(resource, reason, message, type);
+    }
+}

--- a/src/KubeOps/Operator/Events/EventType.cs
+++ b/src/KubeOps/Operator/Events/EventType.cs
@@ -1,0 +1,21 @@
+﻿using k8s.Models;
+
+namespace KubeOps.Operator.Events
+{
+    /// <summary>
+    /// The type of a <see cref="Corev1Event"/>.
+    /// The event type will be stringified and used as <see cref="Corev1Event.Type"/>.
+    /// </summary>
+    public enum EventType
+    {
+        /// <summary>
+        /// A normal event, informative value.
+        /// </summary>
+        Normal,
+
+        /// <summary>
+        /// A warning, something might went wrong.
+        /// </summary>
+        Warning,
+    }
+}

--- a/src/KubeOps/Operator/Events/IEventManager.cs
+++ b/src/KubeOps/Operator/Events/IEventManager.cs
@@ -1,0 +1,84 @@
+﻿using System.Threading.Tasks;
+using k8s;
+using k8s.Models;
+
+namespace KubeOps.Operator.Events
+{
+    /// <summary>
+    /// Event manager for <see cref="Corev1Event"/> objects.
+    /// Contains various utility methods for emitting events on objects.
+    /// </summary>
+    public interface IEventManager
+    {
+        /// <summary>
+        /// Delegate that publishes a predefined event for a statically given resource.
+        /// This delegate should be created with
+        /// <see cref="IEventManager.CreatePublisher(IKubernetesObject{k8s.Models.V1ObjectMeta},string,string,KubeOps.Operator.Events.EventType)"/>.
+        /// When called, the publisher creates or updates the event defined by the params.
+        /// </summary>
+        /// <returns>A task that completes when the event is published.</returns>
+        public delegate Task StaticPublisher();
+
+        /// <summary>
+        /// Delegate that publishes a predefined event for a resource that is passed.
+        /// This delegate should be created with
+        /// <see cref="IEventManager.CreatePublisher(string,string,KubeOps.Operator.Events.EventType)"/>.
+        /// When called with a resource, the publisher creates or updates the event defined by the params.
+        /// </summary>
+        /// <param name="resource">The resource on which the event should be published.</param>
+        /// <returns>A task that completes when the event is published.</returns>
+        public delegate Task Publisher(IKubernetesObject<V1ObjectMeta> resource);
+
+        /// <summary>
+        /// Publish an event in relation to a given resource.
+        /// The event is created or updated if it exists.
+        /// </summary>
+        /// <param name="resource">The resource that is involved with the event.</param>
+        /// <param name="reason">The reason string. This should be a machine readable reason string.</param>
+        /// <param name="message">A human readable string for the event.</param>
+        /// <param name="type">The type of the event.</param>
+        /// <returns>A task that finishes when the event is created or updated.</returns>
+        Task Publish(
+            IKubernetesObject<V1ObjectMeta> resource,
+            string reason,
+            string message,
+            EventType type = EventType.Normal);
+
+        /// <summary>
+        /// Create or update an event.
+        /// </summary>
+        /// <param name="event">The full event object that should be created or updated.</param>
+        /// <returns>A task that finishes when the event is created or updated.</returns>
+        Task Publish(Corev1Event @event);
+
+        /// <summary>
+        /// Create a <see cref="Publisher"/> for a predefined event.
+        /// The <see cref="Publisher"/> is then called with a resource (<see cref="IKubernetesObject{V1ObjectMeta}"/>).
+        /// The predefined event is published with this resource as the involved object.
+        /// </summary>
+        /// <param name="reason">The reason string. This should be a machine readable reason string.</param>
+        /// <param name="message">A human readable string for the event.</param>
+        /// <param name="type">The type of the event.</param>
+        /// <returns>A <see cref="Publisher"/> delegate that can be called to create or update events.</returns>
+        Publisher CreatePublisher(
+            string reason,
+            string message,
+            EventType type = EventType.Normal);
+
+        /// <summary>
+        /// Create a <see cref="StaticPublisher"/> for a predefined event.
+        /// The <see cref="StaticPublisher"/> is then called without any parameters.
+        /// The predefined event is published with the initially given resource as the involved object.
+        /// </summary>
+        /// <param name="resource">The resource that is involved with the event.</param>
+        /// <param name="reason">The reason string. This should be a machine readable reason string.</param>
+        /// <param name="message">A human readable string for the event.</param>
+        /// <param name="type">The type of the event.</param>
+        /// <returns>A <see cref="StaticPublisher"/> delegate that can be called to create or update events.</returns>
+        StaticPublisher CreatePublisher(
+            IKubernetesObject<V1ObjectMeta> resource,
+            string reason,
+            string message,
+            EventType type = EventType.Normal);
+    }
+}

--- a/tests/KubeOps.Test/Operator/Events/EventManager.Test.cs
+++ b/tests/KubeOps.Test/Operator/Events/EventManager.Test.cs
@@ -1,0 +1,214 @@
+﻿using System;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using DotnetKubernetesClient;
+using FluentAssertions;
+using k8s;
+using k8s.Models;
+using KubeOps.Operator;
+using KubeOps.Operator.Events;
+using Microsoft.Extensions.Logging;
+using Moq;
+using SimpleBase;
+using Xunit;
+
+namespace KubeOps.Test.Operator.Events
+{
+    public class EventManagerTest
+    {
+        private readonly Mock<IKubernetesClient> _mockedClient = new();
+        private readonly IEventManager _manager;
+
+        public EventManagerTest()
+        {
+            _manager = new EventManager(
+                _mockedClient.Object,
+                new OperatorSettings { Name = "test-operator" },
+                new Mock<ILogger<EventManager>>(MockBehavior.Loose).Object);
+        }
+
+        [Fact]
+        public async Task Should_Publish_Event_Directly_On_ApiClient()
+        {
+            _mockedClient.Setup(client => client.Save(It.IsAny<Corev1Event>()));
+            _mockedClient.Verify(client => client.Save(It.IsAny<Corev1Event>()), Times.Never);
+
+            await _manager.Publish(new Corev1Event());
+
+            _mockedClient.Verify(client => client.Save(It.IsAny<Corev1Event>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Should_Publish_With_New_Event()
+        {
+            var (eventName, testResource) = GetTestEvent();
+
+            _mockedClient
+                .Setup(client => client.Get<Corev1Event>(eventName, testResource.Namespace()))
+                .Returns(Task.FromResult<Corev1Event?>(null));
+            _mockedClient.Setup(client => client.Save(It.IsAny<Corev1Event>()));
+            _mockedClient.Verify(client => client.Save(It.IsAny<Corev1Event>()), Times.Never);
+
+            await _manager.Publish(testResource, "REASON", "MESSAGE");
+
+            _mockedClient.Verify(client => client.Save(It.IsAny<Corev1Event>()), Times.Once);
+            _mockedClient.Verify(client => client.Get<Corev1Event>(eventName, testResource.Namespace()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Should_Publish_With_Existing_Event()
+        {
+            var (eventName, testResource) = GetTestEvent();
+
+            _mockedClient
+                .Setup(client => client.Get<Corev1Event>(eventName, testResource.Namespace()))
+                .Returns(
+                    Task.FromResult<Corev1Event?>(
+                        new Corev1Event
+                        {
+                            Metadata = new V1ObjectMeta
+                            {
+                                Uid = "1234",
+                                Name = eventName,
+                                NamespaceProperty = testResource.Namespace(),
+                            },
+                            Count = 1,
+                            LastTimestamp = DateTime.MinValue,
+                        }));
+            _mockedClient.Setup(client => client.Save(It.IsAny<Corev1Event>()));
+            _mockedClient.Verify(client => client.Save(It.IsAny<Corev1Event>()), Times.Never);
+
+            await _manager.Publish(testResource, "REASON", "MESSAGE");
+
+            _mockedClient.Verify(client => client.Get<Corev1Event>(eventName, testResource.Namespace()), Times.Once);
+            _mockedClient.Verify(
+                client => client.Save(
+                    It.Is<Corev1Event>(
+                        ev => ev.Name() == eventName && ev.Uid() == "1234")),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task Should_Update_Event_Count_On_Existing_Event()
+        {
+            var (eventName, testResource) = GetTestEvent();
+
+            _mockedClient
+                .Setup(client => client.Get<Corev1Event>(eventName, testResource.Namespace()))
+                .Returns(
+                    Task.FromResult<Corev1Event?>(
+                        new Corev1Event
+                        {
+                            Metadata = new V1ObjectMeta
+                            {
+                                Uid = "1234",
+                                Name = eventName,
+                                NamespaceProperty = testResource.Namespace(),
+                            },
+                            Count = 4,
+                            LastTimestamp = DateTime.MinValue,
+                        }));
+            _mockedClient.Setup(client => client.Save(It.IsAny<Corev1Event>()));
+            _mockedClient.Verify(client => client.Save(It.IsAny<Corev1Event>()), Times.Never);
+
+            await _manager.Publish(testResource, "REASON", "MESSAGE");
+
+            _mockedClient.Verify(client => client.Get<Corev1Event>(eventName, testResource.Namespace()), Times.Once);
+            _mockedClient.Verify(
+                client => client.Save(
+                    It.Is<Corev1Event>(
+                        ev => ev.Uid() == "1234" && ev.Count == 5)),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task Should_Set_Event_Count_On_New_Event()
+        {
+            var (eventName, testResource) = GetTestEvent();
+
+            _mockedClient
+                .Setup(client => client.Get<Corev1Event>(eventName, testResource.Namespace()))
+                .Returns(Task.FromResult<Corev1Event?>(null));
+            _mockedClient.Setup(client => client.Save(It.IsAny<Corev1Event>()));
+            _mockedClient.Verify(client => client.Save(It.IsAny<Corev1Event>()), Times.Never);
+
+            await _manager.Publish(testResource, "REASON", "MESSAGE");
+
+            _mockedClient.Verify(client => client.Get<Corev1Event>(eventName, testResource.Namespace()), Times.Once);
+            _mockedClient.Verify(
+                client => client.Save(
+                    It.Is<Corev1Event>(
+                        ev => ev.Uid() == null && ev.Count == 1)),
+                Times.Once);
+        }
+
+        [Fact]
+        public void Should_Return_StaticPublisher()
+        {
+            var (_, testResource) = GetTestEvent();
+            var pub = _manager.CreatePublisher(testResource, "REASON", "MESSAGE");
+
+            pub.Should().BeOfType<IEventManager.StaticPublisher>();
+        }
+
+        [Fact]
+        public void Should_Return_Publisher()
+        {
+            var pub = _manager.CreatePublisher("REASON", "MESSAGE");
+
+            pub.Should().BeOfType<IEventManager.Publisher>();
+        }
+
+        [Fact]
+        public async Task Should_Publish_With_StaticPublisher()
+        {
+            var (eventName, testResource) = GetTestEvent();
+            _mockedClient
+                .Setup(client => client.Get<Corev1Event>(eventName, testResource.Namespace()))
+                .Returns(Task.FromResult<Corev1Event?>(null));
+            _mockedClient.Setup(client => client.Save(It.IsAny<Corev1Event>()));
+
+            var pub = _manager.CreatePublisher(testResource, "REASON", "MESSAGE");
+            await pub();
+
+            _mockedClient.Verify(client => client.Save(It.Is<Corev1Event>(ev => ev.Name() == eventName)), Times.Once);
+        }
+
+        [Fact]
+        public async Task Should_Publish_With_Publisher()
+        {
+            var (eventName, testResource) = GetTestEvent();
+            _mockedClient
+                .Setup(client => client.Get<Corev1Event>(eventName, testResource.Namespace()))
+                .Returns(Task.FromResult<Corev1Event?>(null));
+            _mockedClient.Setup(client => client.Save(It.IsAny<Corev1Event>()));
+
+            var pub = _manager.CreatePublisher("REASON", "MESSAGE");
+            await pub(testResource);
+
+            _mockedClient.Verify(client => client.Save(It.Is<Corev1Event>(ev => ev.Name() == eventName)), Times.Once);
+        }
+
+        private static (string EventName, IKubernetesObject<V1ObjectMeta> TestResource) GetTestEvent()
+        {
+            var resource = new TestResource();
+            var name = Base32.Rfc4648.Encode(
+                SHA512.HashData(
+                    Encoding.UTF8.GetBytes(
+                        $"{resource.Name()}.{resource.Namespace()}.REASON.MESSAGE.{EventType.Normal}")));
+
+            return (name, resource);
+        }
+
+        private class TestResource : IKubernetesObject<V1ObjectMeta>
+        {
+            public string ApiVersion { get; set; } = "testing.dev/v1";
+
+            public string Kind { get; set; } = "test";
+
+            public V1ObjectMeta Metadata { get; set; } =
+                new() { Name = "test-resource", NamespaceProperty = "test-ns" };
+        }
+    }
+}

--- a/tests/KubeOps.Test/Operator/Leadership/LeaderElector.Test.cs
+++ b/tests/KubeOps.Test/Operator/Leadership/LeaderElector.Test.cs
@@ -16,9 +16,9 @@ namespace KubeOps.Test.Operator.Leadership
     public class LeaderElectorTest
     {
         private readonly LeaderElector _elector;
-        private readonly Mock<ILeaderElection> _election = new Mock<ILeaderElection>();
-        private readonly Mock<IKubernetesClient> _client = new Mock<IKubernetesClient>();
-        private readonly Mock<ILogger<LeaderElector>> _logger = new Mock<ILogger<LeaderElector>>();
+        private readonly Mock<ILeaderElection> _election = new();
+        private readonly Mock<IKubernetesClient> _client = new();
+        private readonly Mock<ILogger<LeaderElector>> _logger = new();
 
         public LeaderElectorTest()
         {


### PR DESCRIPTION
This closes #5.

The provided IEventManager helps with publishing
singleton events (fire and forget) and event series.
The event-name is deterministic, so if the same event
is published multiple times, an event series is created
(when used with Publish(string,string...)).

/cc @ocdi 