### PR TITLE
fix: Expand code generator support for enumerable and collection types

### DIFF
--- a/tests/KubeOps.Test/Operator/Entities/CrdGeneration.Test.cs
+++ b/tests/KubeOps.Test/Operator/Entities/CrdGeneration.Test.cs
@@ -7,7 +7,6 @@ using k8s.Models;
 using KubeOps.Operator.Commands.Generators;
 using KubeOps.Operator.Entities.Extensions;
 using KubeOps.Operator.Errors;
-using KubeOps.Operator.Services;
 using KubeOps.Test.TestEntities;
 using Xunit;
 
@@ -74,30 +73,43 @@ namespace KubeOps.Test.Operator.Entities
             nullableField.Nullable.Should().BeTrue();
         }
 
-        [Fact]
-        public void Should_Set_The_Correct_Array_Type()
+        [Theory]
+        [InlineData(nameof(TestSpecEntitySpec.StringArray), "string", null)]
+        [InlineData(nameof(TestSpecEntitySpec.NullableStringArray), "string", true)]
+        [InlineData(nameof(TestSpecEntitySpec.EnumerableInteger), "integer", null)]
+        [InlineData(nameof(TestSpecEntitySpec.EnumerableNullableInteger), "integer", null)]
+        [InlineData(nameof(TestSpecEntitySpec.IntegerList), "integer", null)]
+        [InlineData(nameof(TestSpecEntitySpec.IntegerHashSet), "integer", null)]
+        [InlineData(nameof(TestSpecEntitySpec.IntegerISet), "integer", null)]
+        [InlineData(nameof(TestSpecEntitySpec.IntegerIReadOnlySet), "integer", null)]
+        public void Should_Set_The_Correct_Array_Type(string property, string expectedType, bool? expectedNullable)
         {
+            var propertyName = char.ToLowerInvariant(property[0]) + property[1..];
             var crd = _testSpecEntity.CreateCrd();
             var specProperties = crd.Spec.Versions.First().Schema.OpenAPIV3Schema.Properties["spec"];
 
-            var normalField = specProperties.Properties["stringArray"];
+            var normalField = specProperties.Properties[propertyName];
             normalField.Type.Should().Be("array");
-            (normalField.Items as V1JSONSchemaProps)?.Type?.Should().Be("string");
-            normalField.Nullable.Should().BeNull();
-
-            var nullableField = specProperties.Properties["nullableStringArray"];
-            nullableField.Type.Should().Be("array");
-            (nullableField.Items as V1JSONSchemaProps)?.Type?.Should().Be("string");
-            nullableField.Nullable.Should().BeTrue();
+            (normalField.Items as V1JSONSchemaProps)?.Type?.Should().Be(expectedType);
+            normalField.Nullable.Should().Be(expectedNullable);
         }
 
-        [Fact]
-        public void Should_Set_The_Correct_Complex_Array_Type()
+        [Theory]
+        [InlineData(nameof(TestSpecEntitySpec.ComplexItemsEnumerable))]
+        [InlineData(nameof(TestSpecEntitySpec.ComplexItemsList))]
+        [InlineData(nameof(TestSpecEntitySpec.ComplexItemsIList))]
+        [InlineData(nameof(TestSpecEntitySpec.ComplexItemsReadOnlyList))]
+        [InlineData(nameof(TestSpecEntitySpec.ComplexItemsCollection))]
+        [InlineData(nameof(TestSpecEntitySpec.ComplexItemsICollection))]
+        [InlineData(nameof(TestSpecEntitySpec.ComplexItemsReadOnlyCollection))]
+        [InlineData(nameof(TestSpecEntitySpec.ComplexItemsDerivedList))]
+        public void Should_Set_The_Correct_Complex_Array_Type(string property)
         {
+            var propertyName = char.ToLowerInvariant(property[0]) + property[1..];
             var crd = _testSpecEntity.CreateCrd();
             var specProperties = crd.Spec.Versions.First().Schema.OpenAPIV3Schema.Properties["spec"];
 
-            var complexItemsArray = specProperties.Properties["complexItems"];
+            var complexItemsArray = specProperties.Properties[propertyName];
             complexItemsArray.Type.Should().Be("array");
             (complexItemsArray.Items as V1JSONSchemaProps)?.Type?.Should().Be("object");
             complexItemsArray.Nullable.Should().BeNull();

--- a/tests/KubeOps.Test/TestEntities/TestSpecEntity.cs
+++ b/tests/KubeOps.Test/TestEntities/TestSpecEntity.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using k8s.Models;
 using KubeOps.Operator.Entities;
@@ -11,9 +12,21 @@ namespace KubeOps.Test.TestEntities
     [Description("This is the Spec Class Description")]
     public class TestSpecEntitySpec
     {
-        public string[] StringArray { get; set; } = new string[0];
+        public string[] StringArray { get; set; } = Array.Empty<string>();
 
         public string[]? NullableStringArray { get; set; }
+
+        public IEnumerable<int> EnumerableInteger { get; set; } = Array.Empty<int>();
+
+        public IEnumerable<int?> EnumerableNullableInteger { get; set; } = Array.Empty<int?>();
+
+        public IntegerList IntegerList { get; set; } = new();
+
+        public HashSet<int> IntegerHashSet { get; set; } = new();
+
+        public ISet<int> IntegerISet { get; set; } = new HashSet<int>();
+
+        public IReadOnlySet<int> IntegerIReadOnlySet { get; set; } = new HashSet<int>();
 
         [AdditionalPrinterColumn]
         public string NormalString { get; set; } = string.Empty;
@@ -80,7 +93,21 @@ namespace KubeOps.Test.TestEntities
         [Required]
         public int Required { get; set; }
 
-        public IEnumerable<TestItem> ComplexItems { get; set; } = Enumerable.Empty<TestItem>();
+        public IEnumerable<TestItem> ComplexItemsEnumerable { get; set; } = Enumerable.Empty<TestItem>();
+
+        public List<TestItem> ComplexItemsList { get; set; } = new();
+
+        public IList<TestItem> ComplexItemsIList { get; set; } = Array.Empty<TestItem>();
+
+        public IReadOnlyList<TestItem> ComplexItemsReadOnlyList { get; set; } = Array.Empty<TestItem>();
+
+        public Collection<TestItem> ComplexItemsCollection { get; set; } = new();
+
+        public ICollection<TestItem> ComplexItemsICollection { get; set; } = Array.Empty<TestItem>();
+
+        public IReadOnlyCollection<TestItem> ComplexItemsReadOnlyCollection { get; set; } = Array.Empty<TestItem>();
+
+        public TestItemList ComplexItemsDerivedList { get; set; } = new();
 
         public IDictionary Dictionary { get; set; } = new Dictionary<string, string>();
 
@@ -116,5 +143,13 @@ namespace KubeOps.Test.TestEntities
         public string Name { get; set; } = null!;
         public string Item { get; set; } = null!;
         public string Extra { get; set; } = null!;
+    }
+
+    public class TestItemList : List<TestItem>
+    {
+    }
+
+    public class IntegerList : Collection<int>
+    {
     }
 }


### PR DESCRIPTION
This fixes #152 by expanding the collection types the CRD code generator can correctly declare as `array` in the JSON Schema.