### PR TITLE
fix: CRD schema type for x-kubernetes-embedded-resource should be object

### DIFF
--- a/src/KubeOps/Operator/Entities/Extensions/EntityToCrdExtensions.cs
+++ b/src/KubeOps/Operator/Entities/Extensions/EntityToCrdExtensions.cs
@@ -180,7 +180,7 @@ namespace KubeOps.Operator.Entities.Extensions
             // check if embedded resource is set
             if (info.GetCustomAttribute<EmbeddedResourceAttribute>() != null)
             {
-                props.Type = null;
+                props.Type = Object;
                 props.Properties = null;
                 props.XKubernetesPreserveUnknownFields = true;
                 props.XKubernetesEmbeddedResource = true;

--- a/tests/KubeOps.Test/Operator/Entities/CrdGeneration.Test.cs
+++ b/tests/KubeOps.Test/Operator/Entities/CrdGeneration.Test.cs
@@ -338,6 +338,7 @@ namespace KubeOps.Test.Operator.Entities
             var crd = _testSpecEntity.CreateCrd();
 
             var specProperties = crd.Spec.Versions.First().Schema.OpenAPIV3Schema.Properties["spec"];
+            specProperties.Properties["kubernetesObject"].Type.Should().Be("object");
             specProperties.Properties["kubernetesObject"].Properties.Should().BeNull();
             specProperties.Properties["kubernetesObject"].XKubernetesPreserveUnknownFields.Should().BeTrue();
             specProperties.Properties["kubernetesObject"].XKubernetesEmbeddedResource.Should().BeTrue();


### PR DESCRIPTION
This fixes #156 by setting the `type` of embedded resource properties to `object` in the generated schema.