### PR TITLE
fix: CRD schema generator does not take JsonProperty.PropertyName value into consideration

### DIFF
--- a/src/KubeOps/Operator/Util/StringExtensions.cs
+++ b/src/KubeOps/Operator/Util/StringExtensions.cs
@@ -1,0 +1,10 @@
+﻿namespace KubeOps.Operator.Util
+{
+    internal static class StringExtensions
+    {
+        internal static string ToCamelCase(this string value) =>
+            string.IsNullOrWhiteSpace(value)
+                ? value
+                : char.ToLowerInvariant(value[0]) + value[1..];
+    }
+}

--- a/src/KubeOps/Operator/Util/StringExtensions.cs
+++ b/src/KubeOps/Operator/Util/StringExtensions.cs
@@ -3,7 +3,7 @@
     internal static class StringExtensions
     {
         internal static string ToCamelCase(this string value) =>
-            string.IsNullOrWhiteSpace(value)
+            string.IsNullOrWhiteSpace(value) || char.IsLower(value[0])
                 ? value
                 : char.ToLowerInvariant(value[0]) + value[1..];
     }

--- a/tests/KubeOps.Test/TestEntities/TestSpecEntity.cs
+++ b/tests/KubeOps.Test/TestEntities/TestSpecEntity.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using k8s.Models;
 using KubeOps.Operator.Entities;
 using KubeOps.Operator.Entities.Annotations;
+using Newtonsoft.Json;
 
 namespace KubeOps.Test.TestEntities
 {
@@ -123,6 +124,9 @@ namespace KubeOps.Test.TestEntities
 
         [EmbeddedResource]
         public V1ConfigMap KubernetesObject { get; set; } = new V1ConfigMap();
+
+        [JsonProperty(PropertyName = "NameFromAttribute")]
+        public string PropertyWithJsonAttribute { get; set; } = string.Empty;
 
         public enum TestSpecEnum
         {


### PR DESCRIPTION
This fixes #158 by setting the schema property name to the `JsonPropertyAttribute.PropertyName` value if set on the `PropertyInfo` instance before applying camel-casing.