### PR TITLE
feat(crd generation): Treat IKubernetesObject types as x-kubernetes-embedded-resource

### DIFF
--- a/src/KubeOps/Operator/Entities/Extensions/EntityToCrdExtensions.cs
+++ b/src/KubeOps/Operator/Entities/Extensions/EntityToCrdExtensions.cs
@@ -249,6 +249,8 @@ namespace KubeOps.Operator.Entities.Extensions
                 props.XKubernetesIntOrString = true;
             }
             else if (typeof(IKubernetesObject).IsAssignableFrom(type) &&
+                     !type.IsAbstract &&
+                     !type.IsInterface &&
                      type.Assembly == typeof(IKubernetesObject).Assembly)
             {
                 SetEmbeddedResourceProperties(props);

--- a/src/KubeOps/Operator/Entities/Extensions/EntityToCrdExtensions.cs
+++ b/src/KubeOps/Operator/Entities/Extensions/EntityToCrdExtensions.cs
@@ -182,10 +182,7 @@ namespace KubeOps.Operator.Entities.Extensions
             // check if embedded resource is set
             if (info.GetCustomAttribute<EmbeddedResourceAttribute>() != null)
             {
-                props.Type = Object;
-                props.Properties = null;
-                props.XKubernetesPreserveUnknownFields = true;
-                props.XKubernetesEmbeddedResource = true;
+                SetEmbeddedResourceProperties(props);
             }
 
             // get additional printer column information
@@ -251,6 +248,11 @@ namespace KubeOps.Operator.Entities.Extensions
             {
                 props.XKubernetesIntOrString = true;
             }
+            else if (typeof(IKubernetesObject).IsAssignableFrom(type) &&
+                     type.Assembly == typeof(IKubernetesObject).Assembly)
+            {
+                SetEmbeddedResourceProperties(props);
+            }
             else if (!isSimpleType)
             {
                 ProcessType(type, props, additionalColumns, jsonPath);
@@ -304,6 +306,14 @@ namespace KubeOps.Operator.Entities.Extensions
             }
 
             return props;
+        }
+
+        private static void SetEmbeddedResourceProperties(V1JSONSchemaProps props)
+        {
+            props.Type = Object;
+            props.Properties = null;
+            props.XKubernetesPreserveUnknownFields = true;
+            props.XKubernetesEmbeddedResource = true;
         }
 
         private static void ProcessType(

--- a/tests/KubeOps.Test/Operator/Entities/CrdGeneration.Test.cs
+++ b/tests/KubeOps.Test/Operator/Entities/CrdGeneration.Test.cs
@@ -336,7 +336,7 @@ namespace KubeOps.Test.Operator.Entities
 
         [Theory]
         [InlineData(nameof(TestSpecEntitySpec.KubernetesObject))]
-        [InlineData(nameof(TestSpecEntitySpec.PolymorphicKubernetesObject))]
+        [InlineData(nameof(TestSpecEntitySpec.Pod))]
         public void Should_Map_Embedded_Resources(string property)
         {
             var crd = _testSpecEntity.CreateCrd();
@@ -349,13 +349,11 @@ namespace KubeOps.Test.Operator.Entities
             specProperties.Properties[propertyName].XKubernetesEmbeddedResource.Should().BeTrue();
         }
 
-        [Theory]
-        [InlineData(nameof(TestSpecEntitySpec.Pods))]
-        [InlineData(nameof(TestSpecEntitySpec.PolymorphicKubernetesObjects))]
-        public void Should_Map_List_Of_Embedded_Resource(string property)
+        [Fact]
+        public void Should_Map_List_Of_Embedded_Resource()
         {
             var crd = _testSpecEntity.CreateCrd();
-            var propertyName = property.ToCamelCase();
+            var propertyName = nameof(TestSpecEntitySpec.Pods).ToCamelCase();
 
             var specProperties = crd.Spec.Versions.First().Schema.OpenAPIV3Schema.Properties["spec"];
             var arrayProperty = specProperties.Properties[propertyName];

--- a/tests/KubeOps.Test/Operator/Entities/CrdGeneration.Test.cs
+++ b/tests/KubeOps.Test/Operator/Entities/CrdGeneration.Test.cs
@@ -334,16 +334,37 @@ namespace KubeOps.Test.Operator.Entities
             specProperties.Properties["intOrString"].XKubernetesIntOrString.Should().BeTrue();
         }
 
-        [Fact]
-        public void Should_Map_Embedded_Resources()
+        [Theory]
+        [InlineData(nameof(TestSpecEntitySpec.KubernetesObject))]
+        [InlineData(nameof(TestSpecEntitySpec.PolymorphicKubernetesObject))]
+        public void Should_Map_Embedded_Resources(string property)
         {
             var crd = _testSpecEntity.CreateCrd();
+            var propertyName = property.ToCamelCase();
 
             var specProperties = crd.Spec.Versions.First().Schema.OpenAPIV3Schema.Properties["spec"];
-            specProperties.Properties["kubernetesObject"].Type.Should().Be("object");
-            specProperties.Properties["kubernetesObject"].Properties.Should().BeNull();
-            specProperties.Properties["kubernetesObject"].XKubernetesPreserveUnknownFields.Should().BeTrue();
-            specProperties.Properties["kubernetesObject"].XKubernetesEmbeddedResource.Should().BeTrue();
+            specProperties.Properties[propertyName].Type.Should().Be("object");
+            specProperties.Properties[propertyName].Properties.Should().BeNull();
+            specProperties.Properties[propertyName].XKubernetesPreserveUnknownFields.Should().BeTrue();
+            specProperties.Properties[propertyName].XKubernetesEmbeddedResource.Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineData(nameof(TestSpecEntitySpec.Pods))]
+        [InlineData(nameof(TestSpecEntitySpec.PolymorphicKubernetesObjects))]
+        public void Should_Map_List_Of_Embedded_Resource(string property)
+        {
+            var crd = _testSpecEntity.CreateCrd();
+            var propertyName = property.ToCamelCase();
+
+            var specProperties = crd.Spec.Versions.First().Schema.OpenAPIV3Schema.Properties["spec"];
+            var arrayProperty = specProperties.Properties[propertyName];
+            arrayProperty.Type.Should().Be("array");
+
+            var items = arrayProperty.Items as V1JSONSchemaProps;
+            items?.Type?.Should().Be("object");
+            items?.XKubernetesPreserveUnknownFields.Should().BeTrue();
+            items?.XKubernetesEmbeddedResource?.Should().BeTrue();
         }
 
         [Fact]

--- a/tests/KubeOps.Test/TestEntities/TestSpecEntity.cs
+++ b/tests/KubeOps.Test/TestEntities/TestSpecEntity.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using k8s;
 using k8s.Models;
 using KubeOps.Operator.Entities;
 using KubeOps.Operator.Entities.Annotations;
@@ -124,6 +125,12 @@ namespace KubeOps.Test.TestEntities
 
         [EmbeddedResource]
         public V1ConfigMap KubernetesObject { get; set; } = new V1ConfigMap();
+
+        public IKubernetesObject PolymorphicKubernetesObject { get; set; } = new V1Pod();
+
+        public IList<V1Pod> Pods { get; set; } = Array.Empty<V1Pod>();
+
+        public IList<IKubernetesObject> PolymorphicKubernetesObjects { get; set; } = Array.Empty<IKubernetesObject>();
 
         [JsonProperty(PropertyName = "NameFromAttribute")]
         public string PropertyWithJsonAttribute { get; set; } = string.Empty;

--- a/tests/KubeOps.Test/TestEntities/TestSpecEntity.cs
+++ b/tests/KubeOps.Test/TestEntities/TestSpecEntity.cs
@@ -126,11 +126,9 @@ namespace KubeOps.Test.TestEntities
         [EmbeddedResource]
         public V1ConfigMap KubernetesObject { get; set; } = new V1ConfigMap();
 
-        public IKubernetesObject PolymorphicKubernetesObject { get; set; } = new V1Pod();
+        public V1Pod Pod { get; set; } = new V1Pod();
 
         public IList<V1Pod> Pods { get; set; } = Array.Empty<V1Pod>();
-
-        public IList<IKubernetesObject> PolymorphicKubernetesObjects { get; set; } = Array.Empty<IKubernetesObject>();
 
         [JsonProperty(PropertyName = "NameFromAttribute")]
         public string PropertyWithJsonAttribute { get; set; } = string.Empty;


### PR DESCRIPTION
Update the CRD generator to treat all `IKubernetesObject` types from the k8s client assembly as embedded resources.

This allows properties to be declared that are arrays of `IKubernetesObject` or its derived types.

```c#
public IList<V1Pod> Pods { get; set; } = Array.Empty<V1Pod>();
```

It also means that properties do not have to have the `EmbeddedResourceAttribute` applied to result in the correct schema being generated.

```c#
public IKubernetesObject PolymorphicKubernetesObject { get; set; } = new V1Pod();
```