### PR TITLE
docs(templates): provide documentation for kubeops templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug Report
+about: Create a report to help fix a problem
+title: ''
+labels: bug
+assignees: ''
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+If applicable: A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Q&A and Discussions
+    url: https://github.com/buehler/dotnet-operator-sdk/discussions
+    about: Please use Discussions for Q&A

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,16 @@
+---
+name: Feature Request
+about: Suggest a new feature for this project
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/docs/docs/templates.md
+++ b/docs/docs/templates.md
@@ -1,0 +1,72 @@
+# Dotnet New Templates
+
+To use the operator SDK as easy as possible, there exists a
+[Nuget Package](https://www.nuget.org/packages/KubeOps.Templates)
+that contains `dotnet new` templates.
+These templates enable developers to create Kubernetes operators.
+
+## Installation
+
+To install the template package, use the `dotnet` cli
+(or you may use the exact version as provided in the link above):
+
+```bash
+dotnet new --install KubeOps.Templates::*
+```
+
+As soon as the templates are installed, you may use them with:
+
+```bash
+dotnet new operator
+#or
+dotnet new operator-empty
+```
+
+Note that several of the templates are available in multiple languages
+of the .NET framework (i.e. C\# and F\#) and you may switch the
+language with the `-lang` flag of `dotnet new`.
+
+## Templates
+
+### Empty Operator
+
+_Available Languages_: C\#, F\#
+
+_Type_: Generate a project
+
+_Templatename_: `operator-empty`
+
+_Example installation_: `dotnet new -n MyOperator operator-empty`
+
+_Description_:
+This template contains the well known `Program.cs`
+and `Startup.cs` files of any other `ASP.NET` project
+and configures the startup file to use KubeObs.
+No additional code is provided.
+
+### Demo Operator
+
+_Available Languages_: C\#, F\#
+
+_Type_: Generate a project
+
+_Templatename_: `operator`
+
+_Example installation_: `dotnet new -n MyOperator operator`
+
+_Description_:
+This template contains the well known `Program.cs`
+and `Startup.cs` files of any other `ASP.NET` project
+and configures the startup file to use KubeObs.
+In addition to the empty operator, an example file
+for each "concept" is provided. You'll find an
+example implementation of:
+
+- A resource controller
+- A custom entity (that generates a CRD)
+- A finalizer
+- A validation webhook
+- A mutation webhook
+
+This template is meant to show all possible elements
+of KubeOps in one go.

--- a/docs/docs/toc.yml
+++ b/docs/docs/toc.yml
@@ -22,3 +22,5 @@
   href: ms_build.md
 - name: Testing
   href: testing.md
+- name: Dotnet New Templates
+  href: templates.md


### PR DESCRIPTION
This provides documentation for the various templates
(operator and operator empty) in the kubeops.templates
package.

Additionally, github issue templates are provided to
ease up creation of issues.

This closes #171.