### PR TITLE
Remove modification/usage of default JsonSerializerSettings

### DIFF
--- a/src/KubeOps/Operator/Builder/OperatorBuilder.cs
+++ b/src/KubeOps/Operator/Builder/OperatorBuilder.cs
@@ -107,9 +107,7 @@ namespace KubeOps.Operator.Builder
 
         internal IOperatorBuilder AddOperatorBase(OperatorSettings settings)
         {
-            Services.AddSingleton(settings);
-
-            var jsonSettings = new JsonSerializerSettings
+            settings.SerializerSettings = new JsonSerializerSettings
             {
                 DateFormatHandling = DateFormatHandling.IsoDateFormat,
                 DateTimeZoneHandling = DateTimeZoneHandling.Utc,
@@ -123,8 +121,8 @@ namespace KubeOps.Operator.Builder
                 },
                 DateFormatString = "yyyy'-'MM'-'dd'T'HH':'mm':'ss.ffffffK",
             };
-            Services.AddTransient(_ => jsonSettings);
-            JsonConvert.DefaultSettings = () => jsonSettings;
+
+            Services.AddSingleton(settings);
 
             Services.AddTransient(
                 _ => new SerializerBuilder()

--- a/src/KubeOps/Operator/Builder/OperatorBuilder.cs
+++ b/src/KubeOps/Operator/Builder/OperatorBuilder.cs
@@ -107,21 +107,6 @@ namespace KubeOps.Operator.Builder
 
         internal IOperatorBuilder AddOperatorBase(OperatorSettings settings)
         {
-            settings.SerializerSettings = new JsonSerializerSettings
-            {
-                DateFormatHandling = DateFormatHandling.IsoDateFormat,
-                DateTimeZoneHandling = DateTimeZoneHandling.Utc,
-                NullValueHandling = NullValueHandling.Ignore,
-                ReferenceLoopHandling = ReferenceLoopHandling.Serialize,
-                ContractResolver = new NamingConvention(),
-                Converters = new List<JsonConverter>
-                {
-                    new StringEnumConverter { CamelCaseText = true },
-                    new Iso8601TimeSpanConverter(),
-                },
-                DateFormatString = "yyyy'-'MM'-'dd'T'HH':'mm':'ss.ffffffK",
-            };
-
             Services.AddSingleton(settings);
 
             Services.AddTransient(

--- a/src/KubeOps/Operator/HostExtensions.cs
+++ b/src/KubeOps/Operator/HostExtensions.cs
@@ -1,9 +1,7 @@
 ﻿using System.Threading.Tasks;
 using KubeOps.Operator.Commands;
 using McMaster.Extensions.CommandLineUtils;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Newtonsoft.Json;
 
 namespace KubeOps.Operator
 {
@@ -27,8 +25,6 @@ namespace KubeOps.Operator
                 .Conventions
                 .UseDefaultConventions()
                 .UseConstructorInjection(host.Services);
-
-            JsonConvert.DefaultSettings = () => host.Services.GetRequiredService<JsonSerializerSettings>();
 
             return app.ExecuteAsync(args);
         }

--- a/src/KubeOps/Operator/OperatorSettings.cs
+++ b/src/KubeOps/Operator/OperatorSettings.cs
@@ -1,7 +1,11 @@
-﻿using System.Reflection;
+﻿using System.Collections.Generic;
+using System.Reflection;
 using System.Text.RegularExpressions;
 using DotnetKubernetesClient;
+using KubeOps.Operator.Serialization;
+using Microsoft.Rest.Serialization;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace KubeOps.Operator
 {
@@ -92,6 +96,19 @@ namespace KubeOps.Operator
         /// </summary>
         public bool DefaultRequeueAsSameType { get; set; } = false;
 
-        internal JsonSerializerSettings SerializerSettings { get; set; } = null!;
+        internal JsonSerializerSettings SerializerSettings { get; set; } = new()
+        {
+            DateFormatHandling = DateFormatHandling.IsoDateFormat,
+            DateTimeZoneHandling = DateTimeZoneHandling.Utc,
+            NullValueHandling = NullValueHandling.Ignore,
+            ReferenceLoopHandling = ReferenceLoopHandling.Serialize,
+            ContractResolver = new NamingConvention(),
+            Converters = new List<JsonConverter>
+            {
+                new StringEnumConverter { CamelCaseText = true },
+                new Iso8601TimeSpanConverter(),
+            },
+            DateFormatString = "yyyy'-'MM'-'dd'T'HH':'mm':'ss.ffffffK",
+        };
     }
 }

--- a/src/KubeOps/Operator/OperatorSettings.cs
+++ b/src/KubeOps/Operator/OperatorSettings.cs
@@ -1,6 +1,7 @@
 ﻿using System.Reflection;
 using System.Text.RegularExpressions;
 using DotnetKubernetesClient;
+using Newtonsoft.Json;
 
 namespace KubeOps.Operator
 {
@@ -90,5 +91,7 @@ namespace KubeOps.Operator
         /// </para>
         /// </summary>
         public bool DefaultRequeueAsSameType { get; set; } = false;
+
+        internal JsonSerializerSettings SerializerSettings { get; set; } = null!;
     }
 }

--- a/src/KubeOps/Operator/OperatorSettings.cs
+++ b/src/KubeOps/Operator/OperatorSettings.cs
@@ -96,7 +96,7 @@ namespace KubeOps.Operator
         /// </summary>
         public bool DefaultRequeueAsSameType { get; set; } = false;
 
-        internal JsonSerializerSettings SerializerSettings { get; set; } = new()
+        internal JsonSerializerSettings SerializerSettings { get; } = new()
         {
             DateFormatHandling = DateFormatHandling.IsoDateFormat,
             DateTimeZoneHandling = DateTimeZoneHandling.Utc,

--- a/src/KubeOps/Operator/Serialization/EntitySerializer.cs
+++ b/src/KubeOps/Operator/Serialization/EntitySerializer.cs
@@ -9,10 +9,10 @@ namespace KubeOps.Operator.Serialization
         private readonly ISerializer _yaml;
         private readonly JsonSerializerSettings _jsonSettings;
 
-        public EntitySerializer(ISerializer yaml, JsonSerializerSettings jsonSettings)
+        public EntitySerializer(ISerializer yaml, OperatorSettings operatorSettings)
         {
             _yaml = yaml;
-            _jsonSettings = jsonSettings;
+            _jsonSettings = operatorSettings.SerializerSettings;
             _jsonSettings.Formatting = Formatting.Indented;
             _jsonSettings.NullValueHandling = NullValueHandling.Ignore;
         }

--- a/src/KubeOps/Operator/Webhooks/IAdmissionWebhook{TEntity, TResult}.cs
+++ b/src/KubeOps/Operator/Webhooks/IAdmissionWebhook{TEntity, TResult}.cs
@@ -113,8 +113,11 @@ namespace KubeOps.Operator.Webhooks
                         return;
                     }
 
+                    var jsonSerializerSettings = context.RequestServices.GetRequiredService<OperatorSettings>()
+                        .SerializerSettings;
+
                     using var reader = new StreamReader(context.Request.Body);
-                    var review = JsonConvert.DeserializeObject<AdmissionReview<TEntity>>(await reader.ReadToEndAsync());
+                    var review = JsonConvert.DeserializeObject<AdmissionReview<TEntity>>(await reader.ReadToEndAsync(), jsonSerializerSettings);
 
                     if (review.Request == null)
                     {


### PR DESCRIPTION
The library really shouldn't rely upon or modify the default JsonSerializerSettings since other libraries could conflict, user code could muck with it, etc.

This fixes #242