### PR TITLE
Allow forcing of event method for requeued resource

### DIFF
--- a/src/KubeOps/Operator/Controller/ManagedResourceController{TEntity}.cs
+++ b/src/KubeOps/Operator/Controller/ManagedResourceController{TEntity}.cs
@@ -277,7 +277,11 @@ namespace KubeOps.Operator.Controller
                         resource.Name());
                     return;
                 case RequeueEventResult requeue:
-                    // TODO Add a setting to default to requeue as the same type event.
+                    if (_settings.DefaultRequeueAsSameType)
+                    {
+                        requeue = new RequeueEventResult(requeue.RequeueIn, @event);
+                    }
+
                     if (requeue.EventType.HasValue)
                     {
                         _logger.LogInformation(

--- a/src/KubeOps/Operator/Controller/Results/RequeueEventResult.cs
+++ b/src/KubeOps/Operator/Controller/Results/RequeueEventResult.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using KubeOps.Operator.Kubernetes;
 
 namespace KubeOps.Operator.Controller.Results
 {
@@ -6,6 +7,11 @@ namespace KubeOps.Operator.Controller.Results
     {
         public RequeueEventResult(TimeSpan requeueIn)
             : base(requeueIn)
+        {
+        }
+
+        public RequeueEventResult(TimeSpan requeueIn, ResourceEventType eventType)
+            : base(requeueIn, eventType)
         {
         }
     }

--- a/src/KubeOps/Operator/Controller/Results/ResourceControllerResult.cs
+++ b/src/KubeOps/Operator/Controller/Results/ResourceControllerResult.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using KubeOps.Operator.Events;
 using KubeOps.Operator.Kubernetes;
 
 namespace KubeOps.Operator.Controller.Results
@@ -10,12 +11,26 @@ namespace KubeOps.Operator.Controller.Results
     /// </summary>
     public abstract class ResourceControllerResult
     {
-        internal ResourceControllerResult(TimeSpan delay) => RequeueIn = delay;
+        internal ResourceControllerResult(TimeSpan delay)
+        {
+            RequeueIn = delay;
+        }
+
+        internal ResourceControllerResult(TimeSpan delay, ResourceEventType eventType)
+        {
+            RequeueIn = delay;
+            EventType = eventType;
+        }
 
         /// <summary>
         /// Time that should be waited for a requeue.
         /// </summary>
         public TimeSpan RequeueIn { get; }
+
+        /// <summary>
+        /// Type of the event to be queued.
+        /// </summary>
+        public ResourceEventType? EventType { get; }
 
         /// <summary>
         /// Create a <see cref="ResourceControllerResult"/> that requeues a resource
@@ -31,6 +46,21 @@ namespace KubeOps.Operator.Controller.Results
         public static ResourceControllerResult RequeueEvent(TimeSpan delay)
             => new RequeueEventResult(delay);
 
-        // TODO: Requeue with forced event method
+        /// <summary>
+        /// Create a <see cref="ResourceControllerResult"/> that requeues a resource
+        /// with a given delay. When the event fires (after the delay) the resource
+        /// cache is ignored in favor the specified <see cref="ResourceEventType"/>.
+        /// Based on the specified type, the new event triggers the according function.
+        /// </summary>
+        /// <param name="delay">
+        /// The delay. Please note, that a delay of <see cref="TimeSpan.Zero"/>
+        /// will result in an immediate trigger of the function. This can lead to infinite circles.
+        /// </param>
+        /// <param name="eventType">
+        /// The event type to queue.
+        /// </param>
+        /// <returns>The <see cref="ResourceControllerResult"/> with the configured delay and event type.</returns>
+        public static ResourceControllerResult RequeueEvent(TimeSpan delay, ResourceEventType eventType)
+            => new RequeueEventResult(delay, eventType);
     }
 }

--- a/src/KubeOps/Operator/OperatorSettings.cs
+++ b/src/KubeOps/Operator/OperatorSettings.cs
@@ -78,5 +78,17 @@ namespace KubeOps.Operator
         /// <para>The search will be performed on each "Start" of the controller.</para>
         /// </summary>
         public bool PreloadCache { get; set; }
+
+        /// <summary>
+        /// <para>
+        /// If set to true, returning `ResourceControllerResult.RequeueEvent` will
+        /// automatically requeue the event as the same type.
+        /// </para>
+        /// <para>
+        /// For example, if done from a "Created" event, the event will be queued
+        /// again as "Created" instead of (for example) "NotModified".
+        /// </para>
+        /// </summary>
+        public bool DefaultRequeueAsSameType { get; set; } = false;
     }
 }


### PR DESCRIPTION
@buehler What do you think of this as an option to resolve #77?

Adding an extra parameter to `ResourceControllerResult.RequeueEvent()` lets the change be backwards compatible, and adding a flag on the `OperatorSettings` allows for the behavior @sabbadino requested, to have the library default to requeueing with the original event type.