### PR TITLE
feat: Use Localtunnel to improve developer experience

### DIFF
--- a/src/KubeOps/KubeOps.csproj
+++ b/src/KubeOps/KubeOps.csproj
@@ -27,6 +27,7 @@
         <PackageReference Include="CompareNETObjects" Version="4.73.0" />
         <PackageReference Include="DotnetKubernetesClient" Version="2.0.7" />
         <PackageReference Include="JsonDiffPatch" Version="2.0.55" />
+        <PackageReference Include="Localtunnel" Version="1.0.3" />
         <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.1.0" />
         <PackageReference Include="McMaster.Extensions.Hosting.CommandLine" Version="3.1.0" />
         <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="5.0.9" />

--- a/src/KubeOps/Operator/Builder/AssemblyScanner.cs
+++ b/src/KubeOps/Operator/Builder/AssemblyScanner.cs
@@ -25,11 +25,31 @@ namespace KubeOps.Operator.Builder
             _registrationDefinitions =
                 new (Type Type, string MethodName)[]
                     {
-                        new() { Type = typeof(IKubernetesObject<V1ObjectMeta>), MethodName = nameof(OperatorBuilderExtensions.AddEntity) },
-                        new() { Type = typeof(IResourceController<>), MethodName = nameof(OperatorBuilderExtensions.AddController) },
-                        new() { Type = typeof(IResourceFinalizer<>), MethodName = nameof(OperatorBuilderExtensions.AddFinalizer) },
-                        new() { Type = typeof(IValidationWebhook<>), MethodName = nameof(OperatorBuilderExtensions.AddValidationWebhook) },
-                        new() { Type = typeof(IMutationWebhook<>), MethodName = nameof(OperatorBuilderExtensions.AddMutationWebhook) },
+                        new()
+                        {
+                            Type = typeof(IKubernetesObject<V1ObjectMeta>),
+                            MethodName = nameof(OperatorBuilderExtensions.AddEntity),
+                        },
+                        new()
+                        {
+                            Type = typeof(IResourceController<>),
+                            MethodName = nameof(OperatorBuilderExtensions.AddController),
+                        },
+                        new()
+                        {
+                            Type = typeof(IResourceFinalizer<>),
+                            MethodName = nameof(OperatorBuilderExtensions.AddFinalizer),
+                        },
+                        new()
+                        {
+                            Type = typeof(IValidationWebhook<>),
+                            MethodName = nameof(OperatorBuilderExtensions.AddValidationWebhook),
+                        },
+                        new()
+                        {
+                            Type = typeof(IMutationWebhook<>),
+                            MethodName = nameof(OperatorBuilderExtensions.AddMutationWebhook),
+                        },
                     }
                     .Select<(Type Type, string MethodName), (Type Type, MethodInfo RegistrationMethod)>(
                         t => new()
@@ -55,8 +75,10 @@ namespace KubeOps.Operator.Builder
                 .Where(
                     t => t.ComponentType.GetInterfaces()
                         .Any(
-                            i => (i.IsConstructedGenericType && i.GetGenericTypeDefinition().IsEquivalentTo(t.RegistrationDefinition.Type)) ||
-                            (t.RegistrationDefinition.Type.IsConstructedGenericType && i.IsEquivalentTo(t.RegistrationDefinition.Type))))
+                            i => (i.IsConstructedGenericType &&
+                                  i.GetGenericTypeDefinition().IsEquivalentTo(t.RegistrationDefinition.Type)) ||
+                                 (t.RegistrationDefinition.Type.IsConstructedGenericType &&
+                                  i.IsEquivalentTo(t.RegistrationDefinition.Type))))
                 .Select(
                     t => t.RegistrationDefinition.RegistrationMethod.MakeGenericMethod(t.ComponentType));
 

--- a/src/KubeOps/Operator/Builder/ComponentRegistrar.cs
+++ b/src/KubeOps/Operator/Builder/ComponentRegistrar.cs
@@ -19,11 +19,14 @@ namespace KubeOps.Operator.Builder
 
         public ImmutableHashSet<EntityRegistration> EntityRegistrations => _entityRegistrations.ToImmutableHashSet();
 
-        public ImmutableHashSet<ControllerRegistration> ControllerRegistrations => _controllerRegistrations.ToImmutableHashSet();
+        public ImmutableHashSet<ControllerRegistration> ControllerRegistrations =>
+            _controllerRegistrations.ToImmutableHashSet();
 
-        public ImmutableHashSet<FinalizerRegistration> FinalizerRegistrations => _finalizerRegistrations.ToImmutableHashSet();
+        public ImmutableHashSet<FinalizerRegistration> FinalizerRegistrations =>
+            _finalizerRegistrations.ToImmutableHashSet();
 
-        public ImmutableHashSet<ValidatorRegistration> ValidatorRegistrations => _validatorRegistrations.ToImmutableHashSet();
+        public ImmutableHashSet<ValidatorRegistration> ValidatorRegistrations =>
+            _validatorRegistrations.ToImmutableHashSet();
 
         public ImmutableHashSet<MutatorRegistration> MutatorRegistrations => _mutatorRegistrations.ToImmutableHashSet();
 

--- a/src/KubeOps/Operator/Builder/IOperatorBuilder.cs
+++ b/src/KubeOps/Operator/Builder/IOperatorBuilder.cs
@@ -140,5 +140,37 @@ namespace KubeOps.Operator.Builder
         IOperatorBuilder AddMutationWebhook<TImplementation, TEntity>()
             where TImplementation : class, IMutationWebhook<TEntity>
             where TEntity : IKubernetesObject<V1ObjectMeta>;
+
+        /// <summary>
+        /// <para>
+        /// Adds a hosted service to the system that creates a "localtunnel"
+        /// (http://localtunnel.github.io/www/) to the running application.
+        /// The tunnel points to the configured host/port configuration and then
+        /// registers itself as webhook target within Kubernetes. This
+        /// enables developers to easily create webhooks without the requirement
+        /// of registering ngrok / localtunnel urls themselves.
+        /// </para>
+        /// <para>
+        /// This is a convenience method to improve the developer experience.
+        /// Since some IDEs do not gracefully shutdown applications that
+        /// have a debugger attached, the registration may not be removed.
+        /// </para>
+        /// <para>
+        /// It is strongly recommended to use this method only while developing
+        /// or debugging an operator. *Never* use this in production.
+        /// </para>
+        /// </summary>
+        /// <param name="hostname">The hostname that the tunnel should target to proxy.</param>
+        /// <param name="port">The target port to proxy.</param>
+        /// <param name="isHttps">If set to true, the target uses HTTPS.</param>
+        /// <param name="allowUntrustedCertificates">
+        /// If the target uses HTTPS, should self signed / untrusted certificates be allowed or not.
+        /// </param>
+        /// <returns>The builder for chaining.</returns>
+        IOperatorBuilder AddWebhookLocaltunnel(
+            string hostname = "localhost",
+            short port = 5000,
+            bool isHttps = false,
+            bool allowUntrustedCertificates = true);
     }
 }

--- a/src/KubeOps/Operator/Builder/OperatorBuilder.cs
+++ b/src/KubeOps/Operator/Builder/OperatorBuilder.cs
@@ -143,7 +143,8 @@ namespace KubeOps.Operator.Builder
                     services.GetRequiredService<OperatorSettings>(),
                     services.GetRequiredService<IKubernetesClient>(),
                     services.GetRequiredService<MutatingWebhookConfigurationBuilder>(),
-                    services.GetRequiredService<ValidatingWebhookConfigurationBuilder>())
+                    services.GetRequiredService<ValidatingWebhookConfigurationBuilder>(),
+                    services.GetRequiredService<ILoggerFactory>())
                 {
                     Host = hostname,
                     Port = port,

--- a/src/KubeOps/Operator/Builder/OperatorBuilder.cs
+++ b/src/KubeOps/Operator/Builder/OperatorBuilder.cs
@@ -143,8 +143,7 @@ namespace KubeOps.Operator.Builder
                     services.GetRequiredService<OperatorSettings>(),
                     services.GetRequiredService<IKubernetesClient>(),
                     services.GetRequiredService<MutatingWebhookConfigurationBuilder>(),
-                    services.GetRequiredService<ValidatingWebhookConfigurationBuilder>(),
-                    services.GetRequiredService<ILoggerFactory>())
+                    services.GetRequiredService<ValidatingWebhookConfigurationBuilder>())
                 {
                     Host = hostname,
                     Port = port,

--- a/src/KubeOps/Operator/Commands/Management/Webhooks/Register.cs
+++ b/src/KubeOps/Operator/Commands/Management/Webhooks/Register.cs
@@ -78,8 +78,10 @@ namespace KubeOps.Operator.Commands.Management.Webhooks
 
         public async Task<int> OnExecuteAsync(CommandLineApplication app)
         {
-            await app.Out.WriteLineAsync($"Found {_componentRegistrar.ValidatorRegistrations.Count} validator registrations.");
-            await app.Out.WriteLineAsync($"Found {_componentRegistrar.MutatorRegistrations.Count} mutator registrations.");
+            await app.Out.WriteLineAsync(
+                $"Found {_componentRegistrar.ValidatorRegistrations.Count} validator registrations.");
+            await app.Out.WriteLineAsync(
+                $"Found {_componentRegistrar.MutatorRegistrations.Count} mutator registrations.");
 
             var webhookConfig = new WebhookConfig(
                 _settings.Name,

--- a/src/KubeOps/Operator/Controller/ManagedResourceController{TEntity}.cs
+++ b/src/KubeOps/Operator/Controller/ManagedResourceController{TEntity}.cs
@@ -86,15 +86,17 @@ namespace KubeOps.Operator.Controller
             .Select(
                 data => Observable.Return(data).Delay(data.Delay))
             .Switch()
-            .Select(data =>
-                Observable.FromAsync(async () =>
-                {
-                    var queuedEvent = await UpdateResourceData(data.Resource);
+            .Select(
+                data =>
+                    Observable.FromAsync(
+                        async () =>
+                        {
+                            var queuedEvent = await UpdateResourceData(data.Resource);
 
-                    return data.ResourceEvent.HasValue && queuedEvent != null
-                        ? queuedEvent with { ResourceEvent = data.ResourceEvent.Value }
-                        : queuedEvent;
-                }))
+                            return data.ResourceEvent.HasValue && queuedEvent != null
+                                ? queuedEvent with { ResourceEvent = data.ResourceEvent.Value }
+                                : queuedEvent;
+                        }))
             .Switch()
             .Where(data => data != null)
             .Do(
@@ -338,7 +340,6 @@ namespace KubeOps.Operator.Controller
                     resource.Name(),
                     retryCount + 1);
                 _erroredEvents.OnNext(data with { RetryCount = retryCount + 1 });
-                return;
             }
         }
 

--- a/src/KubeOps/Operator/OperatorBuilderExtensions.cs
+++ b/src/KubeOps/Operator/OperatorBuilderExtensions.cs
@@ -26,9 +26,11 @@ namespace KubeOps.Operator
         public static IOperatorBuilder AddController<TImplementation>(this IOperatorBuilder builder)
             where TImplementation : class
         {
-            var entityTypes = typeof(TImplementation).GetInterfaces().Where(t =>
-                    t.IsConstructedGenericType &&
-                    t.GetGenericTypeDefinition().IsEquivalentTo(typeof(IResourceController<>)))
+            var entityTypes = typeof(TImplementation).GetInterfaces()
+                .Where(
+                    t =>
+                        t.IsConstructedGenericType &&
+                        t.GetGenericTypeDefinition().IsEquivalentTo(typeof(IResourceController<>)))
                 .Select(i => i.GenericTypeArguments[0]);
 
             var genericRegistrationMethod = builder
@@ -61,9 +63,11 @@ namespace KubeOps.Operator
         public static IOperatorBuilder AddFinalizer<TImplementation>(this IOperatorBuilder builder)
             where TImplementation : class
         {
-            var entityTypes = typeof(TImplementation).GetInterfaces().Where(t =>
-                    t.IsConstructedGenericType &&
-                    t.GetGenericTypeDefinition().IsEquivalentTo(typeof(IResourceFinalizer<>)))
+            var entityTypes = typeof(TImplementation).GetInterfaces()
+                .Where(
+                    t =>
+                        t.IsConstructedGenericType &&
+                        t.GetGenericTypeDefinition().IsEquivalentTo(typeof(IResourceFinalizer<>)))
                 .Select(i => i.GenericTypeArguments[0]);
 
             var genericRegistrationMethod = builder
@@ -96,9 +100,11 @@ namespace KubeOps.Operator
         public static IOperatorBuilder AddValidationWebhook<TImplementation>(this IOperatorBuilder builder)
             where TImplementation : class
         {
-            var entityTypes = typeof(TImplementation).GetInterfaces().Where(t =>
-                    t.IsConstructedGenericType &&
-                    t.GetGenericTypeDefinition().IsEquivalentTo(typeof(IValidationWebhook<>)))
+            var entityTypes = typeof(TImplementation).GetInterfaces()
+                .Where(
+                    t =>
+                        t.IsConstructedGenericType &&
+                        t.GetGenericTypeDefinition().IsEquivalentTo(typeof(IValidationWebhook<>)))
                 .Select(i => i.GenericTypeArguments[0]);
 
             var genericRegistrationMethod = builder
@@ -131,9 +137,11 @@ namespace KubeOps.Operator
         public static IOperatorBuilder AddMutationWebhook<TImplementation>(this IOperatorBuilder builder)
             where TImplementation : class
         {
-            var entityTypes = typeof(TImplementation).GetInterfaces().Where(t =>
-                    t.IsConstructedGenericType &&
-                    t.GetGenericTypeDefinition().IsEquivalentTo(typeof(IMutationWebhook<>)))
+            var entityTypes = typeof(TImplementation).GetInterfaces()
+                .Where(
+                    t =>
+                        t.IsConstructedGenericType &&
+                        t.GetGenericTypeDefinition().IsEquivalentTo(typeof(IMutationWebhook<>)))
                 .Select(i => i.GenericTypeArguments[0]);
 
             var genericRegistrationMethod = builder

--- a/src/KubeOps/Operator/Rbac/RbacBuilder.cs
+++ b/src/KubeOps/Operator/Rbac/RbacBuilder.cs
@@ -16,13 +16,17 @@ namespace KubeOps.Operator.Rbac
         public RbacBuilder(IComponentRegistrar componentRegistrar)
         {
             var controllerTypes = componentRegistrar.ControllerRegistrations
-                .Select(t => t.ControllerType).ToList();
+                .Select(t => t.ControllerType)
+                .ToList();
             var finalizerTypes = componentRegistrar.FinalizerRegistrations
-                .Select(t => t.FinalizerType).ToList();
+                .Select(t => t.FinalizerType)
+                .ToList();
             var validatorTypes = componentRegistrar.ValidatorRegistrations
-                .Select(t => t.ValidatorType).ToList();
+                .Select(t => t.ValidatorType)
+                .ToList();
             var mutatorTypes = componentRegistrar.MutatorRegistrations
-                .Select(t => t.MutatorType).ToList();
+                .Select(t => t.MutatorType)
+                .ToList();
 
             _componentTypes = Enumerable.Empty<Type>()
                 .Concat(controllerTypes)

--- a/src/KubeOps/Operator/Webhooks/IAdmissionWebhook{TEntity, TResult}.cs
+++ b/src/KubeOps/Operator/Webhooks/IAdmissionWebhook{TEntity, TResult}.cs
@@ -117,7 +117,8 @@ namespace KubeOps.Operator.Webhooks
                         .SerializerSettings;
 
                     using var reader = new StreamReader(context.Request.Body);
-                    var review = JsonConvert.DeserializeObject<AdmissionReview<TEntity>>(await reader.ReadToEndAsync(), jsonSerializerSettings);
+                    var data = await reader.ReadToEndAsync();
+                    var review = JsonConvert.DeserializeObject<AdmissionReview<TEntity>>(data, jsonSerializerSettings);
 
                     if (review.Request == null)
                     {

--- a/src/KubeOps/Operator/Webhooks/IValidationWebhook{TEntity}.cs
+++ b/src/KubeOps/Operator/Webhooks/IValidationWebhook{TEntity}.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using DotnetKubernetesClient.Entities;
+using Newtonsoft.Json;
 
 namespace KubeOps.Operator.Webhooks
 {
@@ -62,7 +63,8 @@ namespace KubeOps.Operator.Webhooks
 
         AdmissionResponse IAdmissionWebhook<TEntity, ValidationResult>.TransformResult(
             ValidationResult result,
-            AdmissionRequest<TEntity> request)
+            AdmissionRequest<TEntity> request,
+            JsonSerializerSettings jsonSettings)
             => new()
             {
                 Allowed = result.Valid,

--- a/src/KubeOps/Operator/Webhooks/MutatingWebhookBuilder.cs
+++ b/src/KubeOps/Operator/Webhooks/MutatingWebhookBuilder.cs
@@ -37,7 +37,8 @@ namespace KubeOps.Operator.Webhooks
 
                         var instance = scope.ServiceProvider.GetRequiredService(mutatorType);
 
-                        var (name, endpoint) = _webhookMetadataBuilder.GetMetadata<MutationResult>(instance, entityType);
+                        var (name, endpoint) =
+                            _webhookMetadataBuilder.GetMetadata<MutationResult>(instance, entityType);
 
                         var clientConfig = new Admissionregistrationv1WebhookClientConfig();
                         if (!string.IsNullOrWhiteSpace(webhookConfig.BaseUrl))

--- a/src/KubeOps/Operator/Webhooks/MutationResult.cs
+++ b/src/KubeOps/Operator/Webhooks/MutationResult.cs
@@ -1,6 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
-
-namespace KubeOps.Operator.Webhooks
+﻿namespace KubeOps.Operator.Webhooks
 {
     /// <summary>
     /// Result that should be returned to kubernetes.
@@ -9,7 +7,7 @@ namespace KubeOps.Operator.Webhooks
     /// </summary>
     public sealed class MutationResult : AdmissionResult
     {
-        internal JToken? ModifiedObject { get; init; }
+        internal object? ModifiedObject { get; init; }
 
         /// <summary>
         /// Utility method that creates a return value that indicates that no changes must be applied.
@@ -24,10 +22,15 @@ namespace KubeOps.Operator.Webhooks
         /// that describes the diff from the original object to the modified object.
         /// </summary>
         /// <param name="modifiedEntity">The modified object.</param>
+        /// <param name="warnings">
+        /// An optional list of warnings/messages given back to the user.
+        /// This could contain a reason why an object was mutated.
+        /// </param>
         /// <returns>A <see cref="MutationResult"/> with a modified object.</returns>
-        public static MutationResult Modified(object modifiedEntity) => new()
+        public static MutationResult Modified(object modifiedEntity, params string[] warnings) => new()
         {
-            ModifiedObject = JToken.FromObject(modifiedEntity),
+            ModifiedObject = modifiedEntity,
+            Warnings = warnings,
         };
 
         internal static MutationResult Fail(int statusCode, string statusMessage) => new()

--- a/src/KubeOps/Operator/Webhooks/WebhookLocalTunnel.cs
+++ b/src/KubeOps/Operator/Webhooks/WebhookLocalTunnel.cs
@@ -19,7 +19,7 @@ namespace KubeOps.Operator.Webhooks
         private readonly IKubernetesClient _kubernetesClient;
         private readonly MutatingWebhookConfigurationBuilder _mutatorBuilder;
         private readonly ValidatingWebhookConfigurationBuilder _validatorBuilder;
-        private readonly LocaltunnelClient _localtunnelClient = new();
+        private readonly LocaltunnelClient _localtunnelClient;
         private Tunnel? _tunnel;
 
         public WebhookLocalTunnel(
@@ -27,8 +27,10 @@ namespace KubeOps.Operator.Webhooks
             OperatorSettings settings,
             IKubernetesClient kubernetesClient,
             MutatingWebhookConfigurationBuilder mutatorBuilder,
-            ValidatingWebhookConfigurationBuilder validatorBuilder)
+            ValidatingWebhookConfigurationBuilder validatorBuilder,
+            ILoggerFactory f)
         {
+            _localtunnelClient = new(f.CreateLogger<LocaltunnelClient>());
             _logger = logger;
             _settings = settings;
             _kubernetesClient = kubernetesClient;

--- a/src/KubeOps/Operator/Webhooks/WebhookLocalTunnel.cs
+++ b/src/KubeOps/Operator/Webhooks/WebhookLocalTunnel.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using DotnetKubernetesClient;
+using k8s.Models;
+using Localtunnel;
+using Localtunnel.Connections;
+using Localtunnel.Tunnels;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace KubeOps.Operator.Webhooks
+{
+    internal class WebhookLocalTunnel : IHostedService, IDisposable
+    {
+        private readonly ILogger<WebhookLocalTunnel> _logger;
+        private readonly OperatorSettings _settings;
+        private readonly IKubernetesClient _kubernetesClient;
+        private readonly MutatingWebhookConfigurationBuilder _mutatorBuilder;
+        private readonly ValidatingWebhookConfigurationBuilder _validatorBuilder;
+        private readonly LocaltunnelClient _localtunnelClient = new();
+        private Tunnel? _tunnel;
+
+        public WebhookLocalTunnel(
+            ILogger<WebhookLocalTunnel> logger,
+            OperatorSettings settings,
+            IKubernetesClient kubernetesClient,
+            MutatingWebhookConfigurationBuilder mutatorBuilder,
+            ValidatingWebhookConfigurationBuilder validatorBuilder)
+        {
+            _logger = logger;
+            _settings = settings;
+            _kubernetesClient = kubernetesClient;
+            _mutatorBuilder = mutatorBuilder;
+            _validatorBuilder = validatorBuilder;
+        }
+
+        public string Host { get; init; } = string.Empty;
+
+        public short Port { get; init; }
+
+        public bool IsHttps { get; init; }
+
+        public bool AllowUntrustedCertificates { get; init; }
+
+        public async Task StartAsync(CancellationToken cancellationToken)
+        {
+            _logger.LogTrace("Try to open localtunnel.");
+            _tunnel ??= await _localtunnelClient.OpenAsync(
+                handle => IsHttps
+                    ? new ProxiedSslTunnelConnection(
+                        handle,
+                        new()
+                        {
+                            Host = Host,
+                            Port = Port,
+                            AllowUntrustedCertificates = AllowUntrustedCertificates,
+                        })
+                    : new ProxiedHttpTunnelConnection(
+                        handle,
+                        new()
+                        {
+                            Host = Host,
+                            Port = Port,
+                        }),
+                cancellationToken: cancellationToken);
+
+            _logger.LogDebug(@"Created localtunnel with id ""{id}""", _tunnel.Information.Id);
+            await _tunnel.StartAsync();
+
+            _logger.LogDebug(
+                @"Started localtunnel with id ""{id}"" on ""{url}""",
+                _tunnel.Information.Id,
+                _tunnel.Information.Url);
+
+            // Register the webhook in Kubernetes.
+            var webhookConfig = new WebhookConfig(
+                _settings.Name,
+                _tunnel.Information.Url.ToString(),
+                null,
+                null);
+
+            var validatorConfig = _validatorBuilder.BuildWebhookConfiguration(webhookConfig);
+            var mutatorConfig = _mutatorBuilder.BuildWebhookConfiguration(webhookConfig);
+
+            await _kubernetesClient.Save(validatorConfig);
+            await _kubernetesClient.Save(mutatorConfig);
+
+            _logger.LogInformation(
+                @"Started localtunnel with id ""{id}"" on ""{url}"" and created kubernetes webhook configs for ""{name}""",
+                _tunnel.Information.Id,
+                _tunnel.Information.Url,
+                _settings.Name);
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            if (_tunnel == null)
+            {
+                _logger.LogInformation("No tunnel available to stop.");
+                return Task.CompletedTask;
+            }
+
+            _tunnel.Stop();
+            _logger.LogInformation(
+                @"Stopped localtunnel with id ""{id}"" on ""{url}""",
+                _tunnel.Information.Id,
+                _tunnel.Information.Url);
+
+            return Task.CompletedTask;
+        }
+
+        public void Dispose()
+        {
+            _tunnel?.Dispose();
+            _localtunnelClient.Dispose();
+        }
+    }
+}

--- a/src/KubeOps/Operator/Webhooks/WebhookLocalTunnel.cs
+++ b/src/KubeOps/Operator/Webhooks/WebhookLocalTunnel.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using DotnetKubernetesClient;
-using k8s.Models;
 using Localtunnel;
 using Localtunnel.Connections;
 using Localtunnel.Tunnels;
@@ -19,7 +17,7 @@ namespace KubeOps.Operator.Webhooks
         private readonly IKubernetesClient _kubernetesClient;
         private readonly MutatingWebhookConfigurationBuilder _mutatorBuilder;
         private readonly ValidatingWebhookConfigurationBuilder _validatorBuilder;
-        private readonly LocaltunnelClient _localtunnelClient;
+        private readonly LocaltunnelClient _localtunnelClient = new();
         private Tunnel? _tunnel;
 
         public WebhookLocalTunnel(
@@ -27,10 +25,8 @@ namespace KubeOps.Operator.Webhooks
             OperatorSettings settings,
             IKubernetesClient kubernetesClient,
             MutatingWebhookConfigurationBuilder mutatorBuilder,
-            ValidatingWebhookConfigurationBuilder validatorBuilder,
-            ILoggerFactory f)
+            ValidatingWebhookConfigurationBuilder validatorBuilder)
         {
-            _localtunnelClient = new(f.CreateLogger<LocaltunnelClient>());
             _logger = logger;
             _settings = settings;
             _kubernetesClient = kubernetesClient;
@@ -58,6 +54,7 @@ namespace KubeOps.Operator.Webhooks
                             Host = Host,
                             Port = Port,
                             AllowUntrustedCertificates = AllowUntrustedCertificates,
+                            RequestProcessor = null,
                         })
                     : new ProxiedHttpTunnelConnection(
                         handle,
@@ -65,6 +62,7 @@ namespace KubeOps.Operator.Webhooks
                         {
                             Host = Host,
                             Port = Port,
+                            RequestProcessor = null,
                         }),
                 cancellationToken: cancellationToken);
 

--- a/tests/KubeOps.TestOperator/Program.cs
+++ b/tests/KubeOps.TestOperator/Program.cs
@@ -1,16 +1,10 @@
-﻿using System.Threading.Tasks;
-using KubeOps.Operator;
+﻿using KubeOps.Operator;
+using KubeOps.TestOperator;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
 
-namespace KubeOps.TestOperator
-{
-    public static class Program
-    {
-        public static Task<int> Main(string[] args) => CreateHostBuilder(args).Build().RunOperatorAsync(args);
+static IHostBuilder CreateHostBuilder(string[] args) =>
+    Host.CreateDefaultBuilder(args)
+        .ConfigureWebHostDefaults(webBuilder => { webBuilder.UseStartup<Startup>(); });
 
-        private static IHostBuilder CreateHostBuilder(string[] args) =>
-            Host.CreateDefaultBuilder(args)
-                .ConfigureWebHostDefaults(webBuilder => { webBuilder.UseStartup<Startup>(); });
-    }
-}
+await CreateHostBuilder(args).Build().RunOperatorAsync(args);

--- a/tests/KubeOps.TestOperator/Startup.cs
+++ b/tests/KubeOps.TestOperator/Startup.cs
@@ -9,7 +9,7 @@ namespace KubeOps.TestOperator
     {
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddKubernetesOperator();
+            services.AddKubernetesOperator().AddWebhookLocaltunnel();
             services.AddTransient<IManager, TestManager.TestManager>();
         }
 


### PR DESCRIPTION
This closes #253. When developing webhooks, one needed to
start the operator locally, then use some technology like "localtunnel"
or "ngrok" to have a tunnel (with HTTPS) to the local running operator
and then register that given randomized url to Kubernetes to
actually call the migrator/validator.

This pull request uses localtunnel as a libary by adding `AddWebhookLocaltunnel`
to the operator builder. With this, the operator creates a localtunnel
during startup and registers itself within Kubernetes with the returned url.

Note: this should never be used in production.