### PR TITLE
feat: Make LeaderElection configurable.

### DIFF
--- a/src/KubeOps/Operator/Builder/OperatorBuilder.cs
+++ b/src/KubeOps/Operator/Builder/OperatorBuilder.cs
@@ -215,8 +215,15 @@ namespace KubeOps.Operator.Builder
                 .ForwardToPrometheus();
 
             // Support for leader election via V1Leases.
-            Services.AddHostedService<LeaderElector>();
-            Services.AddSingleton<ILeaderElection, LeaderElection>();
+            if (settings.EnableLeaderElection)
+            {
+                Services.AddHostedService<LeaderElector>();
+                Services.AddSingleton<ILeaderElection, LeaderElection>();
+            }
+            else
+            {
+                Services.AddSingleton<ILeaderElection, DisabledLeaderElection>();
+            }
 
             // Register event handler
             Services.AddTransient<IEventManager, EventManager>();

--- a/src/KubeOps/Operator/Leadership/DisabledLeaderElection.cs
+++ b/src/KubeOps/Operator/Leadership/DisabledLeaderElection.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+
+namespace KubeOps.Operator.Leadership
+{
+    internal class DisabledLeaderElection : ILeaderElection, IDisposable
+    {
+        private readonly BehaviorSubject<LeaderState> _leadershipChange = new(LeaderState.Leader);
+
+        public IObservable<LeaderState> LeadershipChange => _leadershipChange.DistinctUntilChanged();
+
+        public void Dispose()
+        {
+            _leadershipChange.Dispose();
+        }
+
+        void ILeaderElection.LeadershipChanged(LeaderState state)
+        {
+        }
+    }
+}

--- a/src/KubeOps/Operator/Leadership/LeaderElector.cs
+++ b/src/KubeOps/Operator/Leadership/LeaderElector.cs
@@ -16,8 +16,6 @@ using Timer = System.Timers.Timer;
 
 namespace KubeOps.Operator.Leadership
 {
-    [EntityRbac(typeof(V1Lease), Verbs = RbacVerb.All)]
-    [EntityRbac(typeof(V1Deployment), Verbs = RbacVerb.Get | RbacVerb.List)]
     internal class LeaderElector : IHostedService
     {
         private readonly ILogger<LeaderElector> _logger;

--- a/src/KubeOps/Operator/OperatorSettings.cs
+++ b/src/KubeOps/Operator/OperatorSettings.cs
@@ -56,6 +56,21 @@ namespace KubeOps.Operator
         public string ReadinessEndpoint { get; set; } = "/ready";
 
         /// <summary>
+        /// <para>
+        /// Defines if the leader elector should run. You may disable this,
+        /// if you don't intend to run your operator multiple times.
+        /// </para>
+        /// <para>
+        /// If this is disabled, and an operator runs in multiple instance
+        /// (in the same namespace) it can lead to a "split brain" problem.
+        /// </para>
+        /// <para>
+        /// This could be disabled when developing locally.
+        /// </para>
+        /// </summary>
+        public bool EnableLeaderElection { get; set; } = true;
+
+        /// <summary>
         /// The interval in seconds in which this particular instance of the operator
         /// will check for leader election.
         /// </summary>

--- a/tests/KubeOps.TestOperator/Startup.cs
+++ b/tests/KubeOps.TestOperator/Startup.cs
@@ -9,7 +9,7 @@ namespace KubeOps.TestOperator
     {
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddKubernetesOperator().AddWebhookLocaltunnel();
+            services.AddKubernetesOperator(s => s.EnableLeaderElection = false).AddWebhookLocaltunnel();
             services.AddTransient<IManager, TestManager.TestManager>();
         }
 


### PR DESCRIPTION
This also fixes #254. When no
leader election is used, the operator
is always considered "leader". Furthermore, if leader election
is configured, the RBAC generator
includes V1Lease and V1Deployment rules.

This also closes #255.
