### PR TITLE
fix: Consider EntityTypes for RBAC generation.

### DIFF
--- a/src/KubeOps/Operator/Rbac/RbacBuilder.cs
+++ b/src/KubeOps/Operator/Rbac/RbacBuilder.cs
@@ -28,12 +28,16 @@ namespace KubeOps.Operator.Rbac
             var mutatorTypes = componentRegistrar.MutatorRegistrations
                 .Select(t => t.MutatorType)
                 .ToList();
+            var entityTypes = componentRegistrar.EntityRegistrations
+                .Select(t => t.EntityType)
+                .ToList();
 
             _componentTypes = Enumerable.Empty<Type>()
                 .Concat(controllerTypes)
                 .Concat(finalizerTypes)
                 .Concat(validatorTypes)
                 .Concat(mutatorTypes)
+                .Concat(entityTypes)
                 .Distinct()
                 .ToList();
 

--- a/tests/KubeOps.Test/Operator/Generators/CrdGenerator.Test.cs
+++ b/tests/KubeOps.Test/Operator/Generators/CrdGenerator.Test.cs
@@ -8,7 +8,7 @@ using KubeOps.Operator.Entities;
 using KubeOps.Test.TestEntities;
 using Xunit;
 
-namespace KubeOps.Test.Operator.Util
+namespace KubeOps.Test.Operator.Generators
 {
     public class CrdGeneratorTest
     {
@@ -17,7 +17,7 @@ namespace KubeOps.Test.Operator.Util
         public CrdGeneratorTest()
         {
             var componentRegistrar = new ComponentRegistrar();
-            
+
             componentRegistrar.RegisterEntity<TestIgnoredEntity>();
             componentRegistrar.RegisterEntity<TestInvalidEntity>();
             componentRegistrar.RegisterEntity<TestSpecEntity>();

--- a/tests/KubeOps.Test/Operator/Generators/RbacGenerator.Test.cs
+++ b/tests/KubeOps.Test/Operator/Generators/RbacGenerator.Test.cs
@@ -1,0 +1,53 @@
+﻿using System.Linq;
+using FluentAssertions;
+using k8s.Models;
+using KubeOps.Operator;
+using KubeOps.Operator.Builder;
+using KubeOps.Operator.Entities;
+using KubeOps.Operator.Rbac;
+using KubeOps.Test.TestEntities;
+using Xunit;
+
+namespace KubeOps.Test.Operator.Generators
+{
+    public class RbacGeneratorTest
+    {
+        private readonly ComponentRegistrar _componentRegistrar = new();
+
+        public RbacGeneratorTest()
+        {
+            _componentRegistrar.RegisterEntity<TestSpecEntity>();
+            _componentRegistrar.RegisterEntity<TestClusterSpecEntity>();
+            _componentRegistrar.RegisterEntity<TestStatusEntity>();
+            _componentRegistrar.RegisterEntity<EntityWithRbac>();
+        }
+
+        [Fact]
+        public void Should_Generate_Correct_Rbac_Elements_With_Lease()
+        {
+            var builder = new RbacBuilder(_componentRegistrar, new OperatorSettings());
+            var clusterRole = builder.BuildManagerRbac();
+            clusterRole.Rules.Should().HaveCount(4);
+            clusterRole.Rules.Should().Contain(rule => rule.Resources.Any(resource => resource == "entitywithrbacs"));
+            clusterRole.Rules.Should().Contain(rule => rule.Resources.Any(resource => resource == "leases"));
+            clusterRole.Rules.Should().Contain(rule => rule.Resources.Any(resource => resource == "deployments"));
+            clusterRole.Rules.Should()
+                .Contain(rule => rule.Resources.Any(resource => resource == "deployments/status"));
+        }
+
+        [Fact]
+        public void Should_Generate_Correct_Rbac_Elements_Without_Lease()
+        {
+            var builder = new RbacBuilder(_componentRegistrar, new OperatorSettings { EnableLeaderElection = false });
+            var clusterRole = builder.BuildManagerRbac();
+            clusterRole.Rules.Should().HaveCount(1);
+            clusterRole.Rules.Should().Contain(rule => rule.Resources.Any(resource => resource == "entitywithrbacs"));
+        }
+
+        [EntityRbac(typeof(EntityWithRbac), Verbs = RbacVerb.All)]
+        [KubernetesEntity(Group = "test", ApiVersion = "v1")]
+        private class EntityWithRbac : CustomKubernetesEntity<object>
+        {
+        }
+    }
+}


### PR DESCRIPTION
This enables the RBAC generator to create
roles for entites when the RBAC attribute
is attached to an entity class.
