### PR TITLE
Fix #272: Only regenerate if the assembly changed.

### DIFF
--- a/src/KubeOps/Build/KubeOps.targets
+++ b/src/KubeOps/Build/KubeOps.targets
@@ -42,6 +42,18 @@
         </PropertyGroup>
     </Target>
 
+    <Target Name="GetAssemblyBeforeTimestamp" AfterTargets="BeforeCompile">
+        <PropertyGroup>
+            <KubeOpsAssemblyTimestampBeforeCompile>%(IntermediateAssembly.ModifiedTime)</KubeOpsAssemblyTimestampBeforeCompile>
+        </PropertyGroup>
+    </Target>
+
+    <Target Name="GetAssemblyAfterTimestamp" AfterTargets="CoreCompile">
+        <PropertyGroup>
+            <KubeOpsAssemblyTimestampAfterCompile>%(IntermediateAssembly.ModifiedTime)</KubeOpsAssemblyTimestampAfterCompile>
+        </PropertyGroup>
+    </Target>
+
     <Target Name="GenerateDockerfile" DependsOnTargets="BaseConfig">
         <Message Text="Generating Dockerfile" Importance="high" />
         <Message Text="Dockerfile path: $(KubeOpsDockerfilePath)" Importance="normal" />
@@ -88,7 +100,7 @@
               Command="dotnet $(OutputPath)$(TargetFileName) generator installer --out $(KubeOpsInstallerDir) --format $(KubeOpsInstallerFormat) --crds-dir $(KubeOpsCrdDir) --rbac-dir $(KubeOpsRbacDir) --operator-dir $(KubeOpsOperatorDir)" />
     </Target>
 
-    <Target Name="GenerateAfterBuild" AfterTargets="Build" DependsOnTargets="BaseConfig">
+    <Target Name="GenerateAfterBuild" AfterTargets="Build" DependsOnTargets="BaseConfig" Condition="'$(KubeOpsAssemblyTimestampBeforeCompile)' != '$(KubeOpsAssemblyTimestampAfterCompile)'">
         <CallTarget Condition="'$(KubeOpsSkipDockerfile)' == ''" Targets="GenerateDockerfile" />
         <CallTarget Condition="'$(KubeOpsSkipCrds)' == ''" Targets="GenerateCrds" />
         <CallTarget Condition="'$(KubeOpsSkipRbac)' == ''" Targets="GenerateRbac" />


### PR DESCRIPTION
Resolves #272.

This adds a check for the assembly before/after timestamp and if the timestamps are different then the CRDs, etc. will be generated; if not, it won't regenerate because nothing has changed.

I didn't bother adding a configuration for "always rebuild" because you can force a rebuild by doing a clean. It doesn't seem like you'd want to rebuild every time, right? And if you did, you'd rebuild the whole assembly, which would change the timestamp and trigger a regeneration anyway.