### PR TITLE
feat(Webhooks): Make StatusCode/StatusMessage public.

### DIFF
--- a/src/KubeOps/Operator/Webhooks/AdmissionResult.cs
+++ b/src/KubeOps/Operator/Webhooks/AdmissionResult.cs
@@ -12,7 +12,24 @@ namespace KubeOps.Operator.Webhooks
         {
         }
 
-        internal bool Valid { get; init; } = true;
+        /// <summary>
+        /// Determines if the result of the admission webhook is
+        /// either valid or invalid.
+        /// </summary>
+        public bool Valid { get; init; } = true;
+
+        /// <summary>
+        /// Provides a (http) status code for Kubernetes for an admission result.
+        /// This field may be used to provide additional information to the
+        /// user.
+        /// </summary>
+        public int? StatusCode { get; init; }
+
+        /// <summary>
+        /// Provide an additional status message for the admission result.
+        /// This provides additional information for the user.
+        /// </summary>
+        public string? StatusMessage { get; init; }
 
         /// <summary>
         /// Despite being "valid", the validation can add a list of warnings to the user.
@@ -20,11 +37,7 @@ namespace KubeOps.Operator.Webhooks
         /// Warnings may contain up to 256 characters but they should be limited to 120 characters.
         /// If more than 4096 characters are submitted, additional messages are ignored.
         /// </summary>
-        internal IList<string> Warnings { get; init; } = new List<string>();
-
-        internal int? StatusCode { get; init; }
-
-        internal string? StatusMessage { get; init; }
+        public IList<string> Warnings { get; init; } = new List<string>();
 
         internal static TResult NotImplemented<TResult>()
             where TResult : AdmissionResult, new() => new()


### PR DESCRIPTION
This fixes #288. `StatusCode`, `StatusMessage` and `Valid`
are now public members of the `AdmissionResult` instead of internal ones.
This may help in unit/integration testing webhooks.