### PR TITLE
feat(CRDs): Allow ShortNames to be configured.

### DIFF
--- a/src/KubeOps/Operator/Entities/Annotations/KubernetesEntityShortNamesAttribute.cs
+++ b/src/KubeOps/Operator/Entities/Annotations/KubernetesEntityShortNamesAttribute.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace KubeOps.Operator.Entities.Annotations
+{
+    /// <summary>
+    /// Define "shortNames" for CRDs.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+    public class KubernetesEntityShortNamesAttribute : Attribute
+    {
+        public KubernetesEntityShortNamesAttribute(params string[] shortNames)
+        {
+            ShortNames = shortNames;
+        }
+
+        /// <summary>
+        /// Array of shortnames that should be attached to CRDs.
+        /// </summary>
+        public string[] ShortNames { get; }
+    }
+}

--- a/src/KubeOps/Operator/Entities/Extensions/EntityToCrdExtensions.cs
+++ b/src/KubeOps/Operator/Entities/Extensions/EntityToCrdExtensions.cs
@@ -48,6 +48,15 @@ namespace KubeOps.Operator.Entities.Extensions
                 V1CustomResourceDefinition.KubeKind,
                 new V1ObjectMeta { Name = $"{entityDefinition.Plural}.{entityDefinition.Group}" });
 
+            var shortNames = entityType.GetCustomAttributes<KubernetesEntityShortNamesAttribute>(true)
+                .Aggregate(
+                    new List<string>(),
+                    (list, attribute) =>
+                    {
+                        list.AddRange(attribute.ShortNames);
+                        return list;
+                    });
+
             var spec = crd.Spec;
             spec.Group = entityDefinition.Group;
             spec.Names = new V1CustomResourceDefinitionNames
@@ -56,6 +65,7 @@ namespace KubeOps.Operator.Entities.Extensions
                 ListKind = entityDefinition.ListKind,
                 Singular = entityDefinition.Singular,
                 Plural = entityDefinition.Plural,
+                ShortNames = shortNames.Any() ? shortNames : null,
             };
             spec.Scope = entityDefinition.Scope.ToString();
 

--- a/tests/KubeOps.Test/Operator/Generators/CrdGenerator.Test.cs
+++ b/tests/KubeOps.Test/Operator/Generators/CrdGenerator.Test.cs
@@ -83,5 +83,16 @@ namespace KubeOps.Test.Operator.Generators
                 .Spec.Versions.Should()
                 .HaveCount(2);
         }
+
+        [Fact]
+        public void Should_Add_ShortNames_To_Crd()
+        {
+            _crds
+                .First(c => c.Spec.Names.Kind.Contains("teststatusentity", StringComparison.InvariantCultureIgnoreCase))
+                .Spec.Names.ShortNames.Should()
+                .NotBeNull()
+                .And
+                .Contain(new[] { "foo", "bar", "baz" });
+        }
     }
 }

--- a/tests/KubeOps.Test/TestEntities/TestStatusEntity.cs
+++ b/tests/KubeOps.Test/TestEntities/TestStatusEntity.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using k8s.Models;
 using KubeOps.Operator.Entities;
+using KubeOps.Operator.Entities.Annotations;
 
 namespace KubeOps.Test.TestEntities
 {
@@ -23,6 +24,7 @@ namespace KubeOps.Test.TestEntities
     }
 
     [KubernetesEntity(Group = "kubeops.test.dev", ApiVersion = "V1")]
+    [KubernetesEntityShortNames("foo", "bar", "baz")]
     public class TestStatusEntity : CustomKubernetesEntity<TestStatusEntitySpec, TestStatusEntityStatus>
     {
     }


### PR DESCRIPTION
This closes #271. Adding a custom attribute
`KubernetesEntityShortNames` which can be used
to add `shortNames` to a CRD of an entity.
The attribute needs to be added to the class of
an entity and is inherited.