### PR TITLE
fix: Revert "dictionaries and enumerable key-values should generate map[key]value"

### DIFF
--- a/src/KubeOps/Operator/Entities/Extensions/EntityToCrdExtensions.cs
+++ b/src/KubeOps/Operator/Entities/Extensions/EntityToCrdExtensions.cs
@@ -29,7 +29,6 @@ internal static class EntityToCrdExtensions
     private const string Float = "float";
     private const string Double = "double";
     private const string DateTime = "date-time";
-    private const string Map = "map[{0}]{1}";
 
     private static readonly string[] IgnoredToplevelProperties = { "metadata", "apiversion", "kind" };
 
@@ -239,26 +238,9 @@ internal static class EntityToCrdExtensions
                 additionalColumns,
                 jsonPath);
         }
-        else if (!isSimpleType
-                 && type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IDictionary<,>))
-        {
-            var genericTypes = type.GenericTypeArguments;
-            var keyType = MapType(genericTypes[0], additionalColumns, jsonPath).Type;
-            var valueType = MapType(genericTypes[1], additionalColumns, jsonPath).Type;
-            props.Type = string.Format(Map, keyType, valueType);
-        }
-        else if (!isSimpleType
-                 && type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IEnumerable<>)
-                 && type.GenericTypeArguments.Length == 1 && type.GenericTypeArguments.Single().IsGenericType
-                 && type.GenericTypeArguments.Single().GetGenericTypeDefinition() == typeof(KeyValuePair<,>))
-        {
-            var genericTypes = type.GenericTypeArguments.Single().GenericTypeArguments;
-            var keyType = MapType(genericTypes[0], additionalColumns, jsonPath).Type;
-            var valueType = MapType(genericTypes[1], additionalColumns, jsonPath).Type;
-            props.Type = string.Format(Map, keyType, valueType);
-        }
         else if (!isSimpleType &&
                  (typeof(IDictionary).IsAssignableFrom(type) ||
+                  (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IDictionary<,>)) ||
                   (type.IsGenericType &&
                    type.GetGenericArguments().FirstOrDefault()?.IsGenericType == true &&
                    type.GetGenericArguments().FirstOrDefault()?.GetGenericTypeDefinition() ==

--- a/tests/KubeOps.Test/Operator/Entities/CrdGeneration.Test.cs
+++ b/tests/KubeOps.Test/Operator/Entities/CrdGeneration.Test.cs
@@ -57,8 +57,6 @@ public class CrdGenerationTest
     [InlineData("Bool", "boolean", null)]
     [InlineData("DateTime", "string", "date-time")]
     [InlineData("Enum", "string", null)]
-    [InlineData(nameof(TestSpecEntitySpec.GenericDictionary), "map[string]string", null)]
-    [InlineData(nameof(TestSpecEntitySpec.KeyValueEnumerable), "map[string]string", null)]
     public void Should_Set_The_Correct_Type_And_Format_For_Types(string fieldName, string typeName, string? format)
     {
         var crd = _testSpecEntity.CreateCrd();
@@ -274,21 +272,21 @@ public class CrdGenerationTest
     }
 
     [Fact]
-    public void Should_Not_Set_Preserve_Unknown_Fields_On_Generic_Dictionaries()
+    public void Should_Set_Preserve_Unknown_Fields_On_Generic_Dictionaries()
     {
         var crd = _testSpecEntity.CreateCrd();
-        
+
         var specProperties = crd.Spec.Versions.First().Schema.OpenAPIV3Schema.Properties["spec"];
-        specProperties.Properties["genericDictionary"].XKubernetesPreserveUnknownFields.Should().BeNull();
+        specProperties.Properties["genericDictionary"].XKubernetesPreserveUnknownFields.Should().BeTrue();
     }
 
     [Fact]
-    public void Should_Not_Set_Preserve_Unknown_Fields_On_KeyValuePair_Enumerable()
+    public void Should_Set_Preserve_Unknown_Fields_On_KeyValuePair_Enumerable()
     {
         var crd = _testSpecEntity.CreateCrd();
 
         var specProperties = crd.Spec.Versions.First().Schema.OpenAPIV3Schema.Properties["spec"];
-        specProperties.Properties["keyValueEnumerable"].XKubernetesPreserveUnknownFields.Should().BeNull();
+        specProperties.Properties["keyValueEnumerable"].XKubernetesPreserveUnknownFields.Should().BeTrue();
     }
 
     [Fact]

--- a/tests/KubeOps.Test/TestEntities/TestSpecEntity.cs
+++ b/tests/KubeOps.Test/TestEntities/TestSpecEntity.cs
@@ -114,14 +114,8 @@ public class TestSpecEntitySpec
     public IDictionary Dictionary { get; set; } = new Dictionary<string, string>();
 
     public IDictionary<string, string> GenericDictionary { get; set; } = new Dictionary<string, string>();
-    public IDictionary<string, string> NormalGenericDictionary { get; set; } = new Dictionary<string, string>();
-    public IDictionary<string, string>? NullableGenericDictionary { get; set; } = new Dictionary<string, string>();
 
     public IEnumerable<KeyValuePair<string, string>> KeyValueEnumerable { get; set; } =
-        new Dictionary<string, string>();
-    public IEnumerable<KeyValuePair<string, string>> NormalKeyValueEnumerable { get; set; } =
-        new Dictionary<string, string>();
-    public IEnumerable<KeyValuePair<string, string>>? NullableKeyValueEnumerable { get; set; } =
         new Dictionary<string, string>();
 
     [PreserveUnknownFields]


### PR DESCRIPTION
Reverts buehler/dotnet-operator-sdk#350.

@anekdoti has reported a bug with the map[key]value type in CRDs. This does not seem to work like it should.

This fixes #377 