### PR TITLE
Filter K8s Resources from CRD Generation

### DIFF
--- a/src/KubeOps/Operator/Entities/CrdBuilder.cs
+++ b/src/KubeOps/Operator/Entities/CrdBuilder.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -22,6 +22,7 @@ internal class CrdBuilder : ICrdBuilder
     public IEnumerable<V1CustomResourceDefinition> BuildCrds() =>
         _componentRegistrar.EntityRegistrations
             .Select(type => type.EntityType)
+            .Where(type => type.Assembly != typeof(KubernetesEntityAttribute).Assembly)
             .Where(type => type.GetCustomAttributes<KubernetesEntityAttribute>().Any())
             .Where(type => !type.GetCustomAttributes<IgnoreEntityAttribute>().Any())
             .Select(type => (type.CreateCrd(), type.GetCustomAttributes<StorageVersionAttribute>().Any()))

--- a/tests/KubeOps.Test/Operator/Generators/CrdGenerator.Test.cs
+++ b/tests/KubeOps.Test/Operator/Generators/CrdGenerator.Test.cs
@@ -31,6 +31,9 @@ public class CrdGeneratorTest
         componentRegistrar.RegisterEntity<V2Beta2VersionedEntity>();
         componentRegistrar.RegisterEntity<V2VersionedEntity>();
 
+        // Should be ignored since V1Pod is from the k8s assembly.
+        componentRegistrar.RegisterEntity<V1Pod>();
+
         _crds = new CrdBuilder(componentRegistrar).BuildCrds();
     }
 
@@ -45,6 +48,13 @@ public class CrdGeneratorTest
     {
         _crds.Should()
             .NotContain(crd => crd.Name().Contains("ignored", StringComparison.InvariantCultureIgnoreCase));
+    }
+
+    [Fact]
+    public void Should_Not_Contain_K8s_Entities()
+    {
+        _crds.Should()
+             .NotContain(crd => crd.Spec.Names.Kind == "Pod");
     }
 
     [Fact]


### PR DESCRIPTION
This pr filters out non-CRD's (K8s resources such as Pods and Deployments). This resolves #371 (which we are running into too) where if a controller watches a K8s resource, that resource is included in CRD's on generation (which makes K8s unhappy).