### PR TITLE
Flag to Configure Non-Leader Handling

### DIFF
--- a/src/KubeOps/Operator/Controller/ResourceControllerManager.cs
+++ b/src/KubeOps/Operator/Controller/ResourceControllerManager.cs
@@ -11,16 +11,19 @@ internal class ResourceControllerManager : IHostedService
 {
     private readonly IControllerInstanceBuilder _controllerInstanceBuilder;
     private readonly ILeaderElection _leaderElection;
+    private readonly OperatorSettings _operatorSettings;
     private readonly List<IManagedResourceController> _controllerList;
 
     private IDisposable? _leadershipSubscription;
 
     public ResourceControllerManager(
         IControllerInstanceBuilder controllerInstanceBuilder,
-        ILeaderElection leaderElection)
+        ILeaderElection leaderElection,
+        OperatorSettings operatorSettings)
     {
         _controllerInstanceBuilder = controllerInstanceBuilder;
         _leaderElection = leaderElection;
+        _operatorSettings = operatorSettings;
         _controllerList = new List<IManagedResourceController>();
     }
 
@@ -54,7 +57,8 @@ internal class ResourceControllerManager : IHostedService
 
         foreach (var controller in _controllerList)
         {
-            if (state == LeaderState.Leader)
+            if (state == LeaderState.Leader
+                || !_operatorSettings.OnlyWatchEventsWhenLeader)
             {
                 controller.StartAsync();
             }

--- a/src/KubeOps/Operator/OperatorSettings.cs
+++ b/src/KubeOps/Operator/OperatorSettings.cs
@@ -95,6 +95,22 @@ public sealed class OperatorSettings
     public bool EnableLeaderElection { get; set; } = true;
 
     /// <summary>
+    /// <para>
+    /// If set to true, controllers will only watch for new events when in a leader state,
+    /// or if leadership is disabled. When false, this check is disabled,
+    /// controllers will always watch for resource changes regardless of leadership state.
+    /// </para>
+    /// <para>
+    /// If this is disabled, you should consider checking leadership state manually,
+    /// to prevent a "split brain" problem.
+    /// </para>
+    /// <para>
+    /// Defaults to true.
+    /// </para>
+    /// </summary>
+    public bool OnlyWatchEventsWhenLeader { get; set; } = true;
+
+    /// <summary>
     /// The interval in seconds in which this particular instance of the operator
     /// will check for leader election.
     /// </summary>


### PR DESCRIPTION
This pr adds the ability to opt-out of the default "only listen to resource changes while leader" functionality.

This is to handle cases where leadership is handled at a higher level or if instances still need to watch for resource events with not leading, for example,
- Multiple replicas are deployed to a cluster. One instance is elected as a leader.
- Each operator is configured to respond to webhook events (mutation or admission) based on the state of the cluster (since K8s does not have a built-in way to redirect traffic to only some pods).
- For performance, each instance builds an internal cluster state that webhook events use for reference.

This should be a non-breaking change, since the default behavior is preserved.