### PR TITLE
Set PatchType Correctly

### DIFF
--- a/src/KubeOps/Operator/Webhooks/IMutationWebhook{TEntity}.cs
+++ b/src/KubeOps/Operator/Webhooks/IMutationWebhook{TEntity}.cs
@@ -85,6 +85,7 @@ public interface IMutationWebhook<TEntity> : IAdmissionWebhook<TEntity, Mutation
                 serializer);
             var patch = new JsonDiffer().Diff(@object, JToken.FromObject(result.ModifiedObject, serializer), false);
             response.Patch = Convert.ToBase64String(Encoding.UTF8.GetBytes(patch.ToString()));
+            response.PatchType = AdmissionResponse.JsonPatch;
         }
 
         return response;


### PR DESCRIPTION
I was looking though k8s api logs and I noticed this property is missing. This pr sets the PatchType when Patch is set.