### PR TITLE
Set PatchType Correctly (Next)

### DIFF
--- a/src/KubeOps/Operator/Webhooks/AdmissionResponse.cs
+++ b/src/KubeOps/Operator/Webhooks/AdmissionResponse.cs
@@ -20,7 +20,7 @@ internal sealed class AdmissionResponse
     public string[] Warnings { get; init; } = Array.Empty<string>();
 
     [JsonPropertyName("patchType")]
-    public string? PatchType { get; set; } = JsonPatch;
+    public string? PatchType { get; set; }
 
     [JsonPropertyName("patch")]
     public string? Patch { get; set; }

--- a/src/KubeOps/Operator/Webhooks/IMutationWebhook{TEntity}.cs
+++ b/src/KubeOps/Operator/Webhooks/IMutationWebhook{TEntity}.cs
@@ -77,6 +77,7 @@ public interface IMutationWebhook<TEntity> : IAdmissionWebhook<TEntity, Mutation
 
             var patch = KubernetesJsonDiffer.DiffObjects(from, to);
             response.Patch = Convert.ToBase64String(Encoding.UTF8.GetBytes(patch.ToString()));
+            response.PatchType = AdmissionResponse.JsonPatch;
         }
 
         return response;


### PR DESCRIPTION
Same as #446, but for next. This pr cherry-picks the commit from #446 and fixes the `AdmissionResponse` model. This actually throws a warning in the K8s api controller (but there was no other impact).