### PR TITLE
Fixes Exception on Null Finalizers

### DIFF
--- a/src/KubeOps/Operator/Finalizer/FinalizerManager{TEntity}.cs
+++ b/src/KubeOps/Operator/Finalizer/FinalizerManager{TEntity}.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using DotnetKubernetesClient;
@@ -102,7 +103,7 @@ internal class FinalizerManager<TEntity> : IFinalizerManager<TEntity>
             @"Finalization on entity ""{kind}/{name}"" done. Remaining finalizers: ""{remainingFinalizer}"".",
             entity.Kind,
             entity.Name(),
-            string.Join(',', entity.Finalizers()));
+            string.Join(',', entity.Finalizers() ?? Array.Empty<string>()));
     }
 
     private async Task RegisterFinalizerInternalAsync<TFinalizer>(TEntity entity, TFinalizer finalizer)


### PR DESCRIPTION
This pr handles an exception during logging that could be thrown when finalizers are null and not empty. This appears to occur when working with pods.