### PR TITLE
Feature/conversionwebhook

### DIFF
--- a/DotnetOperatorSdk.sln
+++ b/DotnetOperatorSdk.sln
@@ -40,6 +40,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KubeOps.Templates", "src\Ku
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KubeOps.Templates.Test", "tests\KubeOps.Templates.Test\KubeOps.Templates.Test.csproj", "{B88CFB69-709B-4B7D-A1F6-BD8200609770}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KubeOps.Test.Integration", "tests\KubeOps.Test.Integration\KubeOps.Test.Integration.csproj", "{4E9BDF36-6007-408B-ADA9-F8CF278A2BFF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KubeOps.Test.Integration.Operator", "tests\KubeOps.Test.Integration.Operator\KubeOps.Test.Integration.Operator.csproj", "{B86A0CF4-A742-42FF-9A7E-89680C17DAB9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -76,6 +80,14 @@ Global
 		{B88CFB69-709B-4B7D-A1F6-BD8200609770}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B88CFB69-709B-4B7D-A1F6-BD8200609770}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B88CFB69-709B-4B7D-A1F6-BD8200609770}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4E9BDF36-6007-408B-ADA9-F8CF278A2BFF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4E9BDF36-6007-408B-ADA9-F8CF278A2BFF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4E9BDF36-6007-408B-ADA9-F8CF278A2BFF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4E9BDF36-6007-408B-ADA9-F8CF278A2BFF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B86A0CF4-A742-42FF-9A7E-89680C17DAB9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B86A0CF4-A742-42FF-9A7E-89680C17DAB9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B86A0CF4-A742-42FF-9A7E-89680C17DAB9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B86A0CF4-A742-42FF-9A7E-89680C17DAB9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -89,6 +101,8 @@ Global
 		{4A6D1BEB-CB4C-495A-A20D-D8728F6BBC93} = {95F3A6DD-B421-441D-B263-1B34A1465FF5}
 		{210EF3DD-151D-4547-9A35-39C97B887CD0} = {95F3A6DD-B421-441D-B263-1B34A1465FF5}
 		{B88CFB69-709B-4B7D-A1F6-BD8200609770} = {50E9B964-68F7-4B9F-BEA8-165CE45BC5C6}
+		{4E9BDF36-6007-408B-ADA9-F8CF278A2BFF} = {50E9B964-68F7-4B9F-BEA8-165CE45BC5C6}
+		{B86A0CF4-A742-42FF-9A7E-89680C17DAB9} = {50E9B964-68F7-4B9F-BEA8-165CE45BC5C6}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {ADAA5DFB-A7E5-490C-88EF-48D67C715F24}

--- a/src/KubeOps/Operator/ApplicationBuilderExtensions.cs
+++ b/src/KubeOps/Operator/ApplicationBuilderExtensions.cs
@@ -1,10 +1,18 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using DotnetKubernetesClient.Entities;
 using KubeOps.Operator.Builder;
+using KubeOps.Operator.Entities.Extensions;
 using KubeOps.Operator.Webhooks;
+using KubeOps.Operator.Webhooks.ConversionWebhook;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Prometheus;
@@ -16,6 +24,9 @@ namespace KubeOps.Operator;
 /// </summary>
 public static class ApplicationBuilderExtensions
 {
+    private const string ApiVersion = "apiextensions.k8s.io/v1";
+    private const string Kind = "ConversionReview";
+
     /// <summary>
     /// Use the kubernetes operator.
     /// Register routing (.UseRouting()) and endpoints.
@@ -83,6 +94,86 @@ public static class ApplicationBuilderExtensions
                         name,
                         endpoint);
                 }
+
+                RegisterConversionWebhooks(app, logger, componentRegistrar);
             });
+    }
+
+    private static void RegisterConversionWebhooks(IApplicationBuilder app, ILogger logger, IComponentRegistrar componentRegistrar)
+    {
+        app.UseEndpoints(endpoints =>
+        {
+            endpoints.MapPost(
+                "/convert",
+                async context =>
+                {
+                    using var postScope = app.ApplicationServices.CreateScope();
+                    if (!context.Request.HasJsonContentType())
+                    {
+                        logger.LogError("Admission request has no json content type");
+                        context.Response.StatusCode = StatusCodes.Status400BadRequest;
+                        return;
+                    }
+
+                    Response response;
+                    Guid requestUid = Guid.Empty;
+                    try
+                    {
+                        using var reader = new StreamReader(context.Request.Body);
+                        var jsonContent = await reader.ReadToEndAsync();
+                        var desiredApiVersion = JsonNode.Parse(jsonContent)!["request"]!["desiredAPIVersion"]!
+                            .GetValue<string>();
+                        requestUid = JsonNode.Parse(jsonContent)!["request"]!["uid"]!.GetValue<Guid>();
+                        var objectsToConvert = JsonNode.Parse(jsonContent)!["request"]!["objects"]!.AsArray();
+                        logger.LogInformation("Conversion request with id: {Id} desiredApiVersion: {Version}, AmountOfObjectsToConvert: {Amount}", requestUid.ToString(), desiredApiVersion, objectsToConvert.Count);
+                        var convertedObjects = new List<object>();
+                        foreach (var objectToConvert in objectsToConvert)
+                        {
+                            var kind = objectToConvert!["kind"]!.GetValue<string>();
+                            var currentApiVersion = objectToConvert!["apiVersion"]!.GetValue<string>();
+                            (Type webhookTypeToCall, Type entityIn, Type entityOut) =
+                                componentRegistrar.ConversionRegistrations.First(
+                                    cw =>
+                                        cw.EntityIn.CreateResourceDefinition().Kind == kind &&
+                                        cw.EntityIn.CreateResourceDefinition().GroupVersion() == currentApiVersion &&
+                                        cw.EntityOut.CreateResourceDefinition().GroupVersion() == desiredApiVersion);
+                            var input = objectToConvert.Deserialize(
+                                entityIn,
+                                new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+                            var conversionResult = ConvertCustomResource(
+                                postScope,
+                                webhookTypeToCall,
+                                entityIn,
+                                entityOut,
+                                input,
+                                logger);
+                            convertedObjects.Add(conversionResult ?? throw new InvalidOperationException());
+                        }
+
+                        response = new Response(requestUid, Result.Success(), convertedObjects);
+                    }
+                    catch (Exception e)
+                    {
+                        logger.LogError("Error while converting objects: {Exception}", e.Message);
+                        response = new Response(requestUid, Result.Failed("failed converting resources"), null);
+                    }
+
+                    await context.Response.WriteAsJsonAsync(new ConversionResponse(ApiVersion, Kind, response));
+                });
+        });
+    }
+
+    private static object? ConvertCustomResource(IServiceScope postScope, Type webhookTypeToCall, Type entityIn, Type entityOut, object? input, ILogger logger)
+    {
+        var mutator = postScope.ServiceProvider.GetRequiredService(webhookTypeToCall);
+        var genericConvertor = typeof(IConversionWebhook<,>)
+            .MakeGenericType(entityIn, entityOut);
+        var convertMethod = genericConvertor
+            .GetMethods(BindingFlags.Instance | BindingFlags.Public)
+            .First(m => m.Name == "Convert");
+        logger.LogDebug("Invoking method for conversion: {Method}", convertMethod.Name);
+        return convertMethod.Invoke(
+            mutator,
+            new[] { input ?? throw new InvalidOperationException() });
     }
 }

--- a/src/KubeOps/Operator/Builder/AssemblyScanner.cs
+++ b/src/KubeOps/Operator/Builder/AssemblyScanner.cs
@@ -7,6 +7,7 @@ using k8s.Models;
 using KubeOps.Operator.Controller;
 using KubeOps.Operator.Finalizer;
 using KubeOps.Operator.Webhooks;
+using KubeOps.Operator.Webhooks.ConversionWebhook;
 
 namespace KubeOps.Operator.Builder;
 
@@ -49,6 +50,11 @@ internal class AssemblyScanner : IAssemblyScanner
                     {
                         Type = typeof(IMutationWebhook<>),
                         MethodName = nameof(OperatorBuilderExtensions.AddMutationWebhook),
+                    },
+                    new()
+                    {
+                        Type = typeof(IConversionWebhook<,>),
+                        MethodName = nameof(OperatorBuilderExtensions.AddConversionWebhook),
                     },
                 }
                 .Select<(Type Type, string MethodName), (Type Type, MethodInfo RegistrationMethod)>(

--- a/src/KubeOps/Operator/Builder/IComponentRegistrar.cs
+++ b/src/KubeOps/Operator/Builder/IComponentRegistrar.cs
@@ -5,6 +5,7 @@ using k8s.Models;
 using KubeOps.Operator.Controller;
 using KubeOps.Operator.Finalizer;
 using KubeOps.Operator.Webhooks;
+using KubeOps.Operator.Webhooks.ConversionWebhook;
 
 namespace KubeOps.Operator.Builder;
 
@@ -19,6 +20,8 @@ internal interface IComponentRegistrar
     public ImmutableHashSet<ValidatorRegistration> ValidatorRegistrations { get; }
 
     public ImmutableHashSet<MutatorRegistration> MutatorRegistrations { get; }
+
+    public ImmutableHashSet<ConversionRegistration> ConversionRegistrations { get; }
 
     IComponentRegistrar RegisterEntity<TEntity>()
         where TEntity : IKubernetesObject<V1ObjectMeta>;
@@ -39,6 +42,11 @@ internal interface IComponentRegistrar
         where TMutator : class, IMutationWebhook<TEntity>
         where TEntity : IKubernetesObject<V1ObjectMeta>;
 
+    IComponentRegistrar RegisterConversion<TImplementation, TIn, TOut>()
+        where TImplementation : class, IConversionWebhook<TIn, TOut>
+        where TIn : IKubernetesObject<V1ObjectMeta>
+        where TOut : IKubernetesObject<V1ObjectMeta>;
+
     public record EntityRegistration(Type EntityType);
 
     public record ControllerRegistration(Type ControllerType, Type EntityType);
@@ -48,4 +56,6 @@ internal interface IComponentRegistrar
     public record ValidatorRegistration(Type ValidatorType, Type EntityType);
 
     public record MutatorRegistration(Type MutatorType, Type EntityType);
+
+    public record ConversionRegistration(Type ConversionWebhookType, Type EntityIn, Type EntityOut);
 }

--- a/src/KubeOps/Operator/Builder/IOperatorBuilder.cs
+++ b/src/KubeOps/Operator/Builder/IOperatorBuilder.cs
@@ -1,9 +1,11 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using k8s;
 using k8s.Models;
 using KubeOps.Operator.Controller;
 using KubeOps.Operator.Finalizer;
 using KubeOps.Operator.Webhooks;
+using KubeOps.Operator.Webhooks.ConversionWebhook;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
@@ -167,9 +169,15 @@ public interface IOperatorBuilder
     /// If the target uses HTTPS, should self signed / untrusted certificates be allowed or not.
     /// </param>
     /// <returns>The builder for chaining.</returns>
+    [Obsolete("AddWebhookLocalTunnel is deprecated use OperatorSettings.UseLocalTunnel", true)]
     IOperatorBuilder AddWebhookLocaltunnel(
         string hostname = "localhost",
         short port = 5000,
         bool isHttps = false,
         bool allowUntrustedCertificates = true);
+
+    IOperatorBuilder AddConversionWebhook<TImplementation, TIn, TOut>()
+        where TImplementation : class, IConversionWebhook<TIn, TOut>
+        where TIn : IKubernetesObject<V1ObjectMeta>
+        where TOut : IKubernetesObject<V1ObjectMeta>;
 }

--- a/src/KubeOps/Operator/Commands/Management/Webhooks/Install.cs
+++ b/src/KubeOps/Operator/Commands/Management/Webhooks/Install.cs
@@ -8,6 +8,7 @@ using k8s.Models;
 using KubeOps.Operator.Commands.CommandHelpers;
 using KubeOps.Operator.Entities.Extensions;
 using KubeOps.Operator.Webhooks;
+using KubeOps.Operator.Webhooks.ConversionWebhook;
 using McMaster.Extensions.CommandLineUtils;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -23,15 +24,18 @@ internal class Install
     private readonly OperatorSettings _settings;
     private readonly ValidatingWebhookConfigurationBuilder _validatingWebhookConfigurationBuilder;
     private readonly MutatingWebhookConfigurationBuilder _mutatingWebhookConfigurationBuilder;
+    private readonly IConversionWebhookInstaller _conversionWebhookInstaller;
 
     public Install(
         OperatorSettings settings,
         ValidatingWebhookConfigurationBuilder validatingWebhookConfigurationBuilder,
-        MutatingWebhookConfigurationBuilder mutatingWebhookConfigurationBuilder)
+        MutatingWebhookConfigurationBuilder mutatingWebhookConfigurationBuilder,
+        IConversionWebhookInstaller conversionWebhookInstaller)
     {
         _settings = settings;
         _validatingWebhookConfigurationBuilder = validatingWebhookConfigurationBuilder;
         _mutatingWebhookConfigurationBuilder = mutatingWebhookConfigurationBuilder;
+        _conversionWebhookInstaller = conversionWebhookInstaller;
     }
 
     [Option(
@@ -131,6 +135,9 @@ internal class Install
         }
 
         await client.Save(mutatorConfig);
+
+        await app.Out.WriteLineAsync("Creating conversion definitions..");
+        await _conversionWebhookInstaller.InstallConversionWebhooks(webhookConfig);
 
         await app.Out.WriteLineAsync("Installed webhook service and admission configurations.");
 

--- a/src/KubeOps/Operator/Commands/Management/Webhooks/Register.cs
+++ b/src/KubeOps/Operator/Commands/Management/Webhooks/Register.cs
@@ -4,6 +4,7 @@ using DotnetKubernetesClient;
 using k8s.Models;
 using KubeOps.Operator.Builder;
 using KubeOps.Operator.Webhooks;
+using KubeOps.Operator.Webhooks.ConversionWebhook;
 using McMaster.Extensions.CommandLineUtils;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -20,17 +21,20 @@ internal class Register
     private readonly IComponentRegistrar _componentRegistrar;
     private readonly ValidatingWebhookConfigurationBuilder _validatingWebhookConfigurationBuilder;
     private readonly MutatingWebhookConfigurationBuilder _mutatingWebhookConfigurationBuilder;
+    private readonly IConversionWebhookInstaller _conversionWebhookInstaller;
 
     public Register(
         OperatorSettings settings,
         IComponentRegistrar componentRegistrar,
         MutatingWebhookConfigurationBuilder mutatingWebhookConfigurationBuilder,
-        ValidatingWebhookConfigurationBuilder validatingWebhookConfigurationBuilder)
+        ValidatingWebhookConfigurationBuilder validatingWebhookConfigurationBuilder,
+        IConversionWebhookInstaller conversionWebhookInstaller)
     {
         _settings = settings;
         _componentRegistrar = componentRegistrar;
         _mutatingWebhookConfigurationBuilder = mutatingWebhookConfigurationBuilder;
         _validatingWebhookConfigurationBuilder = validatingWebhookConfigurationBuilder;
+        _conversionWebhookInstaller = conversionWebhookInstaller;
     }
 
     [Option(
@@ -101,6 +105,8 @@ internal class Register
         await app.Out.WriteLineAsync($@"Install ""{mutatorConfig.Metadata.Name}"" mutator on cluster.");
         await client.Save(validatorConfig);
         await client.Save(mutatorConfig);
+        await _conversionWebhookInstaller.InstallConversionWebhooks(webhookConfig);
+
 
         return ExitCodes.Success;
     }

--- a/src/KubeOps/Operator/Entities/Extensions/CustomEntityDefinitionExtensionMethods.cs
+++ b/src/KubeOps/Operator/Entities/Extensions/CustomEntityDefinitionExtensionMethods.cs
@@ -1,0 +1,11 @@
+﻿using DotnetKubernetesClient.Entities;
+
+namespace KubeOps.Operator.Entities.Extensions;
+
+public static class CustomEntityDefinitionExtensionMethods
+{
+    public static string GroupVersion(this CustomEntityDefinition ced)
+    {
+        return $"{ced.Group}/{ced.Version}";
+    }
+}

--- a/src/KubeOps/Operator/OperatorSettings.cs
+++ b/src/KubeOps/Operator/OperatorSettings.cs
@@ -175,6 +175,8 @@ public sealed class OperatorSettings
     /// </summary>
     public short HttpsPort { get; set; } = 5001;
 
+    public LocalTunnelSettings LocalTunnelSettings { get; private set; } = new();
+
     /// <summary>
     /// The configuration used when comparing resources against each-other for caching
     /// or other similar processing.
@@ -196,4 +198,29 @@ public sealed class OperatorSettings
         Converters = new List<JsonConverter> { new StringEnumConverter(), new Iso8601TimeSpanConverter(), },
         DateFormatString = "yyyy'-'MM'-'dd'T'HH':'mm':'ss.ffffffK",
     };
+
+    public void UseLocalTunnel(bool allowUntrustedCertificates = true, bool isHttps = false, string host = "localhost", short port = 5000)
+    {
+        LocalTunnelSettings = new LocalTunnelSettings()
+        {
+            AllowUntrustedCertificates = allowUntrustedCertificates,
+            Host = host,
+            Port = port,
+            IsHttps = isHttps,
+            UseLocalTunnel = true,
+        };
+    }
+}
+
+public class LocalTunnelSettings
+{
+    public bool UseLocalTunnel { get; set; } = false;
+
+    public string Host { get; set; } = "localhost";
+
+    public short Port { get; set; }
+
+    public bool IsHttps { get; set; }
+
+    public bool AllowUntrustedCertificates { get; set; }
 }

--- a/src/KubeOps/Operator/Rbac/RbacBuilder.cs
+++ b/src/KubeOps/Operator/Rbac/RbacBuilder.cs
@@ -65,7 +65,8 @@ internal class RbacBuilder : IRbacBuilder
                     new EntityRbacAttribute(
                         typeof(V1Service),
                         typeof(V1ValidatingWebhookConfiguration),
-                        typeof(V1MutatingWebhookConfiguration))
+                        typeof(V1MutatingWebhookConfiguration),
+                        typeof(V1CustomResourceDefinition))
                     {
                         Verbs = RbacVerb.Get | RbacVerb.Create | RbacVerb.Update | RbacVerb.Patch | RbacVerb.Delete,
                     },

--- a/src/KubeOps/Operator/Webhooks/ConversionWebhook/ConversionResponse.cs
+++ b/src/KubeOps/Operator/Webhooks/ConversionWebhook/ConversionResponse.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace KubeOps.Operator.Webhooks.ConversionWebhook;
+
+public record ConversionResponse(string ApiVersion, string Kind, Response Response);
+
+public record Response(Guid Uid, Result Result, List<object>? ConvertedObjects);
+
+public record ConversionResponse<T>(string ApiVersion, string Kind, Response<T> Response);
+
+public record Response<T>(Guid Uid, Result Result, List<T> ConvertedObjects);
+
+public class Result
+{
+    public Result(string status, string? message = null)
+    {
+        Status = status;
+        Message = message;
+    }
+
+    public string Status { get; }
+    public string? Message { get; }
+    public static Result Success() => new Result("Success");
+    public static Result Failed(string message) => new Result("Failed", message);
+
+}
+
+
+

--- a/src/KubeOps/Operator/Webhooks/ConversionWebhook/ConversionReview.cs
+++ b/src/KubeOps/Operator/Webhooks/ConversionWebhook/ConversionReview.cs
@@ -1,0 +1,8 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace KubeOps.Operator.Webhooks.ConversionWebhook;
+
+public record ConversionReview(string ApiVersion, string Kind, Request Request);
+
+public record Request(Guid Uid, string DesiredAPIVersion, List<object> Objects);

--- a/src/KubeOps/Operator/Webhooks/ConversionWebhook/ConversionWebhookBuilder.cs
+++ b/src/KubeOps/Operator/Webhooks/ConversionWebhook/ConversionWebhookBuilder.cs
@@ -1,0 +1,80 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using DotnetKubernetesClient.Entities;
+using k8s.Models;
+using KubeOps.Operator.Builder;
+using KubeOps.Operator.Entities;
+using KubeOps.Operator.Entities.Extensions;
+using Microsoft.Extensions.Logging;
+
+namespace KubeOps.Operator.Webhooks.ConversionWebhook;
+
+internal class ConversionWebhookBuilder : IConversionWebhookBuilder
+{
+    private readonly ICrdBuilder _crdBuilder;
+    private readonly IComponentRegistrar _componentRegistrar;
+    private readonly ILogger<ConversionWebhookBuilder> _logger;
+
+    public ConversionWebhookBuilder(ICrdBuilder crdBuilder, IComponentRegistrar componentRegistrar, ILogger<ConversionWebhookBuilder> logger)
+    {
+        _crdBuilder = crdBuilder;
+        _componentRegistrar = componentRegistrar;
+        _logger = logger;
+    }
+
+    public IEnumerable<V1CustomResourceDefinition> BuildWebhookConfiguration(WebhookConfig webhookConfig, bool isLocalTunnel)
+    {
+        _logger.LogInformation("Building conversionwebhook configuration");
+        var allWebhooks = _componentRegistrar.ConversionRegistrations;
+        if (allWebhooks.Count == 0)
+        {
+            return new List<V1CustomResourceDefinition>();
+        }
+
+        var customResourceDefinitionsToUpdate = _crdBuilder.BuildCrds()
+            .Where(
+                crd => crd.Spec.Versions.Count > 1 &&
+                       allWebhooks.Any(
+                           cr =>
+                           {
+                               return crd.Spec.Versions.Any(
+                                          v => cr.EntityIn.CreateResourceDefinition().GroupVersion() ==
+                                               $"{crd.Spec.Group}/{v.Name}") ||
+                                      crd.Spec.Versions.Any(
+                                          v => cr.EntityOut.CreateResourceDefinition().GroupVersion() ==
+                                               $"{crd.Spec.Group}/{v.Name}");
+                           })).ToList();
+        _logger.LogInformation("Found {AmountOfCustomResourceDefinitions} to update", customResourceDefinitionsToUpdate.Count);
+        foreach (var crd in customResourceDefinitionsToUpdate)
+        {
+            crd.Spec.Conversion = GetConversionWebhookConfiguration(webhookConfig, isLocalTunnel);
+        }
+
+        return customResourceDefinitionsToUpdate;
+    }
+
+    private static V1CustomResourceConversion GetConversionWebhookConfiguration(WebhookConfig webhookConfig, bool isLocalTunnel = false)
+    {
+        if (isLocalTunnel)
+        {
+            return new V1CustomResourceConversion(
+                "Webhook",
+                new V1WebhookConversion(
+                    new List<string> { "v1" },
+                    new Apiextensionsv1WebhookClientConfig
+                    {
+                        Url = $"{webhookConfig.BaseUrl}convert",
+                    }));
+        }
+
+        return new V1CustomResourceConversion(
+            "Webhook",
+            new V1WebhookConversion(
+                new List<string> { "v1" },
+                new Apiextensionsv1WebhookClientConfig
+                {
+                    CaBundle = webhookConfig.CaBundle,
+                    Service = new Apiextensionsv1ServiceReference(webhookConfig.Service?.Name, webhookConfig.Service?.NamespaceProperty, webhookConfig.Service?.Path, webhookConfig.Service?.Port),
+                }));
+    }
+}

--- a/src/KubeOps/Operator/Webhooks/ConversionWebhook/ConversionWebhookInstaller.cs
+++ b/src/KubeOps/Operator/Webhooks/ConversionWebhook/ConversionWebhookInstaller.cs
@@ -1,0 +1,40 @@
+﻿using System.Threading.Tasks;
+using DotnetKubernetesClient;
+using k8s.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Rest;
+
+namespace KubeOps.Operator.Webhooks.ConversionWebhook;
+
+internal class ConversionWebhookInstaller : IConversionWebhookInstaller
+{
+    private readonly IConversionWebhookBuilder _conversionWebhookBuilder;
+    private readonly IKubernetesClient _kubernetesClient;
+    private readonly ILogger<ConversionWebhookInstaller> _logger;
+
+    public ConversionWebhookInstaller(IConversionWebhookBuilder conversionWebhookBuilder, IKubernetesClient kubernetesClient, ILogger<ConversionWebhookInstaller> logger)
+    {
+        _conversionWebhookBuilder = conversionWebhookBuilder;
+        _kubernetesClient = kubernetesClient;
+        _logger = logger;
+    }
+
+    public async Task InstallConversionWebhooks(WebhookConfig webhookConfig, bool isLocalTunnel = false)
+    {
+        var crdsToUpdateWithConversionWebhook = _conversionWebhookBuilder.BuildWebhookConfiguration(webhookConfig, isLocalTunnel);
+        foreach (V1CustomResourceDefinition crd in crdsToUpdateWithConversionWebhook)
+        {
+            try
+            {
+                await _kubernetesClient.Save(crd);
+            }
+            catch (HttpOperationException ex)
+            {
+                _logger.LogCritical("Error saving crd: {Response}", ex.Response.Content);
+                throw;
+            }
+
+            _logger.LogInformation("Registered conversion webhook for {Crd}", crd.Spec.Names.Kind);
+        }
+    }
+}

--- a/src/KubeOps/Operator/Webhooks/ConversionWebhook/IConversionWebhook.cs
+++ b/src/KubeOps/Operator/Webhooks/ConversionWebhook/IConversionWebhook.cs
@@ -1,0 +1,11 @@
+﻿using k8s;
+using k8s.Models;
+
+namespace KubeOps.Operator.Webhooks.ConversionWebhook;
+
+public interface IConversionWebhook<in TIn, out TOut>
+    where TIn : IKubernetesObject<V1ObjectMeta>
+    where TOut : IKubernetesObject<V1ObjectMeta>
+{
+    public TOut Convert(TIn customResourceInput);
+}

--- a/src/KubeOps/Operator/Webhooks/ConversionWebhook/IConversionWebhookBuilder.cs
+++ b/src/KubeOps/Operator/Webhooks/ConversionWebhook/IConversionWebhookBuilder.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+using k8s.Models;
+
+namespace KubeOps.Operator.Webhooks.ConversionWebhook;
+
+internal interface IConversionWebhookBuilder
+{
+    IEnumerable<V1CustomResourceDefinition> BuildWebhookConfiguration(WebhookConfig webhookConfig, bool isLocalTunnel);
+}

--- a/src/KubeOps/Operator/Webhooks/ConversionWebhook/IConversionWebhookInstaller.cs
+++ b/src/KubeOps/Operator/Webhooks/ConversionWebhook/IConversionWebhookInstaller.cs
@@ -1,0 +1,8 @@
+﻿using System.Threading.Tasks;
+
+namespace KubeOps.Operator.Webhooks.ConversionWebhook;
+
+internal interface IConversionWebhookInstaller
+{
+    Task InstallConversionWebhooks(WebhookConfig webhookConfig, bool isLocalTunnel = false);
+}

--- a/tests/KubeOps.Test.Integration.Operator/KubeOps.Test.Integration.Operator.csproj
+++ b/tests/KubeOps.Test.Integration.Operator/KubeOps.Test.Integration.Operator.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <Content Include="Properties\launchSettings.json" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\KubeOps\KubeOps.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/tests/KubeOps.Test.Integration.Operator/Program.cs
+++ b/tests/KubeOps.Test.Integration.Operator/Program.cs
@@ -1,9 +1,6 @@
-﻿using System.Threading.Tasks;
-using KubeOps.Operator;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Hosting;
+﻿using KubeOps.Operator;
 
-namespace KubeOps.TestOperator;
+namespace KubeOps.Test.Integration.Operator;
 
 public class Program
 {

--- a/tests/KubeOps.Test.Integration.Operator/Properties/launchSettings.json
+++ b/tests/KubeOps.Test.Integration.Operator/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+﻿{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:42539",
+      "sslPort": 44363
+    }
+  },
+  "profiles": {
+    "KubeOps.Enhancements.Test.Integration.Operator": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "applicationUrl": "https://localhost:5001;http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/tests/KubeOps.Test.Integration.Operator/Startup.cs
+++ b/tests/KubeOps.Test.Integration.Operator/Startup.cs
@@ -1,0 +1,22 @@
+﻿using KubeOps.Operator;
+
+namespace KubeOps.Test.Integration.Operator;
+
+public class Startup
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.AddKubernetesOperator()
+            .AddEntity<V1TestEntity>()
+            .AddEntity<V2TestEntity>()
+            .AddController<TestController>()
+            .AddConversionWebhook<V1ToV2TestConversionWebhook>()
+            .AddConversionWebhook<V2ToV1TestConversionWebhook>();
+
+    }
+
+    public void Configure(IApplicationBuilder app)
+    {
+        app.UseKubernetesOperator();
+    }
+}

--- a/tests/KubeOps.Test.Integration.Operator/TestController.cs
+++ b/tests/KubeOps.Test.Integration.Operator/TestController.cs
@@ -1,0 +1,47 @@
+﻿using DotnetKubernetesClient;
+using KubeOps.Operator.Controller;
+using KubeOps.Operator.Controller.Results;
+using KubeOps.Operator.Rbac;
+
+namespace KubeOps.Test.Integration.Operator;
+
+[EntityRbac(typeof(V2TestEntity), Verbs = RbacVerb.All)]
+public class TestController : IResourceController<V2TestEntity>
+{
+    private readonly IKubernetesClient _client;
+
+    public TestController(IKubernetesClient client)
+    {
+        _client = client;
+    }
+
+    public async Task<ResourceControllerResult?> ReconcileAsync(V2TestEntity entity)
+    {
+        entity.Status.ReconcileCounter++;
+        switch (entity.Spec.Spec)
+        {
+            case "testException" when entity.Status.ReconcileCounter < 4:
+                await _client.UpdateStatus(entity);
+                throw new ArgumentException(nameof(entity.Spec.Spec));
+            case "testExceptionFail":
+                await _client.UpdateStatus(entity);
+                throw new ArgumentException(nameof(entity.Spec.Spec));
+            case "testDoubleQueued":
+                await _client.UpdateStatus(entity);
+                return ResourceControllerResult.RequeueEvent(TimeSpan.FromSeconds(5));
+        }
+        entity.Status.Status = "Updated";
+        await _client.UpdateStatus(entity);
+        return ResourceControllerResult.RequeueEvent(TimeSpan.FromSeconds(1));
+    }
+
+    public Task StatusModifiedAsync(V2TestEntity entity)
+    {
+        return Task.CompletedTask;
+    }
+
+    public Task DeletedAsync(V2TestEntity entity)
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/tests/KubeOps.Test.Integration.Operator/TestEntity.cs
+++ b/tests/KubeOps.Test.Integration.Operator/TestEntity.cs
@@ -1,0 +1,48 @@
+﻿using k8s.Models;
+using KubeOps.Operator.Entities;
+
+namespace KubeOps.Test.Integration.Operator;
+
+public class V1TestEntitySpec
+{
+    /// <summary>
+    /// This is a test for the contextual fetching of descriptions.
+    /// </summary>
+    public string Spec { get; set; } = string.Empty;
+    public string PlaceHolder { get; set; } = string.Empty;
+
+}
+
+public class V1TestEntityStatus
+{
+    public string Status { get; set; } = string.Empty;
+    public int ReconcileCounter { get; set; }
+
+}
+
+[KubernetesEntity(Group = "integration.testing.dev", ApiVersion = "v1", Kind = "TestEntity")]
+public class V1TestEntity : CustomKubernetesEntity<V1TestEntitySpec, V1TestEntityStatus>
+{
+}
+
+public class V2TestEntitySpec
+{
+    /// <summary>
+    /// This is a test for the contextual fetching of descriptions.
+    /// </summary>
+    public string Spec { get; set; } = string.Empty;
+    public string PlaceHolder { get; set; } = string.Empty;
+
+}
+
+public class V2TestEntityStatus
+{
+    public string Status { get; set; } = string.Empty;
+    public int ReconcileCounter { get; set; }
+
+}
+
+[KubernetesEntity(Group = "integration.testing.dev", ApiVersion = "v2", Kind = "TestEntity")]
+public class V2TestEntity : CustomKubernetesEntity<V2TestEntitySpec, V2TestEntityStatus>
+{
+}

--- a/tests/KubeOps.Test.Integration.Operator/TestEntity.yaml
+++ b/tests/KubeOps.Test.Integration.Operator/TestEntity.yaml
@@ -1,0 +1,8 @@
+﻿apiVersion: integration.testing.dev/v1
+kind: TestEntity
+metadata:
+  name: my-test-entity
+  namespace: default
+spec:
+  spec: stringgg
+  placeHolder: test

--- a/tests/KubeOps.Test.Integration.Operator/V1ToV2TestConversionWebhook.cs
+++ b/tests/KubeOps.Test.Integration.Operator/V1ToV2TestConversionWebhook.cs
@@ -1,0 +1,23 @@
+﻿using KubeOps.Operator.Webhooks.ConversionWebhook;
+
+namespace KubeOps.Test.Integration.Operator;
+
+public class V1ToV2TestConversionWebhook : IConversionWebhook<V1TestEntity, V2TestEntity>
+{
+    public V2TestEntity Convert(V1TestEntity customResourceInput)
+    {
+        if (customResourceInput.Spec.Spec == "throwException")
+        {
+            throw new ArgumentException(null, nameof(customResourceInput));
+        }
+        return new V2TestEntity()
+        {
+            ApiVersion = "integration.testing.dev/v2",
+            Kind = customResourceInput.Kind,Spec = new V2TestEntitySpec()
+            {
+                PlaceHolder = customResourceInput.Spec.PlaceHolder, Spec = customResourceInput.Spec.Spec,
+            },
+            Metadata = customResourceInput.Metadata,
+        };
+    }
+}

--- a/tests/KubeOps.Test.Integration.Operator/V2ToV1TestConversionWebhook.cs
+++ b/tests/KubeOps.Test.Integration.Operator/V2ToV1TestConversionWebhook.cs
@@ -1,0 +1,23 @@
+﻿using KubeOps.Operator.Webhooks.ConversionWebhook;
+
+namespace KubeOps.Test.Integration.Operator;
+
+public class V2ToV1TestConversionWebhook : IConversionWebhook<V2TestEntity, V1TestEntity>
+{
+    public V1TestEntity Convert(V2TestEntity customResourceInput)
+    {
+        if (customResourceInput.Spec.Spec == "throwException")
+        {
+            throw new ArgumentException(null, nameof(customResourceInput));
+        }
+        return new V1TestEntity()
+        {
+            ApiVersion = "integration.testing.dev/v1",
+            Kind = customResourceInput.Kind,Spec = new V1TestEntitySpec()
+            {
+                PlaceHolder = customResourceInput.Spec.PlaceHolder, Spec = customResourceInput.Spec.Spec,
+            },
+            Metadata = customResourceInput.Metadata,
+        };
+    }
+}

--- a/tests/KubeOps.Test.Integration.Operator/appsettings.Development.json
+++ b/tests/KubeOps.Test.Integration.Operator/appsettings.Development.json
@@ -1,9 +1,8 @@
-﻿{
+{
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "System": "Information",
-      "Microsoft": "Information"
+      "Microsoft.AspNetCore": "Warning"
     }
   }
 }

--- a/tests/KubeOps.Test.Integration.Operator/appsettings.json
+++ b/tests/KubeOps.Test.Integration.Operator/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Trace",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/tests/KubeOps.Test.Integration/ConversionWebhookIntegrationTests.cs
+++ b/tests/KubeOps.Test.Integration/ConversionWebhookIntegrationTests.cs
@@ -1,0 +1,93 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using DotnetKubernetesClient;
+using k8s;
+using KubeOps.Operator.Webhooks.ConversionWebhook;
+using KubeOps.Test.Integration.Operator;
+
+namespace KubeOps.Test.Integration;
+
+public class ConversionWebhookIntegrationTests : IDisposable
+{
+
+    private readonly TestOperatorRunner _sut;
+    private readonly IKubernetesClient _kubernetesClient;
+
+    public ConversionWebhookIntegrationTests()
+    {
+        _kubernetesClient =
+            new KubernetesClient(KubernetesClientConfiguration.BuildDefaultConfig());
+        _sut = new TestOperatorRunner();
+
+        // Used to call EnsureServer()
+        var server = _sut.Server;
+    }
+
+    public void Dispose()
+    {
+        _sut.Dispose();
+        _kubernetesClient.Delete<V2TestEntity>("testentity","default");
+        _kubernetesClient.Delete<V2TestEntity>("testentity1","default");
+    }
+
+    [Fact]
+    public async Task ConversionWebhookShouldReturnV2TestEntity()
+    {
+        //Arrange
+        using var client = _sut.CreateClient();
+        var guid = Guid.NewGuid();
+        var request = new Request(guid, "integration.testing.dev/v2", new List<object>() { new V1TestEntity(){Kind = "TestEntity", ApiVersion = "integration.testing.dev/v1",} });
+        var conversionReview = new ConversionReview(
+            "integration.testing.dev/v1",
+            "ConversionReview",
+            request);
+        var content = JsonContent.Create(conversionReview, typeof(ConversionReview));
+        //Act
+        var responseMessage = await client.PostAsync("/convert", content);
+        Assert.True(responseMessage.IsSuccessStatusCode);
+        var jsonContent = await responseMessage.Content.ReadAsStringAsync();
+        var responseContent = JsonSerializer.Deserialize<ConversionResponse<V2TestEntity>>(jsonContent, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        //Assert
+        Assert.NotNull(responseContent);
+        Assert.Equal(guid,responseContent.Response.Uid);
+        Assert.Equal("Success",responseContent.Response.Result.Status);
+        Assert.Single(responseContent.Response.ConvertedObjects!);
+        Assert.Equal("integration.testing.dev/v2",responseContent.Response.ConvertedObjects!.First().ApiVersion);
+    }
+
+    [Fact]
+    public async Task ConversionWebhookShouldReturnBadRequestIfNoJSON()
+    {
+        //Arrange
+        using var client = _sut.CreateClient();
+        //Act
+        var responseMessage = await client.PostAsync("/convert", null);
+        //Assert
+        Assert.Equal(HttpStatusCode.BadRequest, responseMessage.StatusCode);
+    }
+
+    [Fact]
+    public async Task ConversionWebhookShouldReturnResultFailedWhenExceptionThrown()
+    {
+        //Arrange
+        using var client = _sut.CreateClient();
+        var guid = Guid.NewGuid();
+        var request = new Request(guid, "integration.testing.dev/v2", new List<object>() { new V1TestEntity()
+        {
+            Kind = "TestEntity", ApiVersion = "integration.testing.dev/v1",Spec = new V1TestEntitySpec(){Spec = "throwException"},
+        }});
+        var conversionReview = new ConversionReview(
+            "integration.testing.dev/v1",
+            "ConversionReview",
+            request);
+        var content = JsonContent.Create(conversionReview, typeof(ConversionReview));
+        //Act
+        var responseMessage = await client.PostAsync("/convert", content);
+        Assert.True(responseMessage.IsSuccessStatusCode);
+        var responseContent = await JsonSerializer.DeserializeAsync<ConversionResponse<V2TestEntity>>(await responseMessage.Content.ReadAsStreamAsync(),new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        //Assert
+        Assert.NotNull(responseContent);
+        Assert.Equal("Failed",responseContent.Response.Result.Status);
+    }
+}

--- a/tests/KubeOps.Test.Integration/KubeOps.Test.Integration.csproj
+++ b/tests/KubeOps.Test.Integration/KubeOps.Test.Integration.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="DotnetKubernetesClient" Version="2.1.11" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.5" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="3.1.2">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\KubeOps.Test.Integration.Operator\KubeOps.Test.Integration.Operator.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/tests/KubeOps.Test.Integration/TestOperatorRunner.cs
+++ b/tests/KubeOps.Test.Integration/TestOperatorRunner.cs
@@ -1,0 +1,16 @@
+﻿using KubeOps.Operator;
+using KubeOps.Test.Integration.Operator;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Hosting;
+
+namespace KubeOps.Test.Integration;
+
+internal class TestOperatorRunner : WebApplicationFactory<Program>
+{
+    protected override IHost CreateHost(IHostBuilder builder)
+    {
+        var host = base.CreateHost(builder);
+        host.RunOperatorAsync(new []{"install"});
+        return host;
+    }
+}

--- a/tests/KubeOps.Test.Integration/Usings.cs
+++ b/tests/KubeOps.Test.Integration/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/tests/KubeOps.Test/Operator/OperatorSettingsTests.cs
+++ b/tests/KubeOps.Test/Operator/OperatorSettingsTests.cs
@@ -1,0 +1,38 @@
+﻿using KubeOps.Operator;
+using Xunit;
+
+namespace KubeOps.Test.Operator;
+
+public class OperatorSettingsTests
+{
+    [Fact]
+    public void UseLocalTunnelShouldSetLocalTunnelPropertyInOperatorSettingsStandardValues()
+    {
+        //Arrange
+        var settings = new OperatorSettings();
+        //Act
+        settings.UseLocalTunnel();
+        //Assert
+        Assert.Equal("localhost", settings.LocalTunnelSettings.Host);
+        Assert.Equal(5000,settings.LocalTunnelSettings.Port);
+        Assert.False(settings.LocalTunnelSettings.IsHttps);
+        Assert.True(settings.LocalTunnelSettings.AllowUntrustedCertificates);
+        Assert.True(settings.LocalTunnelSettings.UseLocalTunnel);
+    }
+
+    [Fact]
+    public void UseLocalTunnelShouldSetLocalTunnelPropertyInOperatorSettingsNonStandardValues()
+    {
+        //Arrange
+        var settings = new OperatorSettings();
+        //Act
+        settings.UseLocalTunnel(false, true, "testHost", 80);
+        //Assert
+        Assert.Equal("testHost", settings.LocalTunnelSettings.Host);
+        Assert.Equal(80,settings.LocalTunnelSettings.Port);
+        Assert.True(settings.LocalTunnelSettings.IsHttps);
+        Assert.False(settings.LocalTunnelSettings.AllowUntrustedCertificates);
+        Assert.True(settings.LocalTunnelSettings.UseLocalTunnel);
+    }
+
+}

--- a/tests/KubeOps.Test/Operator/Webhook/ConversionWebhook/ConversionWebhookBuilderTests.cs
+++ b/tests/KubeOps.Test/Operator/Webhook/ConversionWebhook/ConversionWebhookBuilderTests.cs
@@ -1,0 +1,109 @@
+﻿using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using k8s.Models;
+using KubeOps.Operator.Builder;
+using KubeOps.Operator.Entities;
+using KubeOps.Operator.Webhooks;
+using KubeOps.Operator.Webhooks.ConversionWebhook;
+using KubeOps.Test.TestEntities;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace KubeOps.Test.Operator.Webhook.ConversionWebhook;
+
+public class ConversionWebhookBuilderTests
+{
+    private readonly ConversionWebhookBuilder _conversionWebhookBuilder;
+    private readonly Mock<ICrdBuilder> _crdBuilder;
+    private readonly Mock<IComponentRegistrar> _componentRegistrar;
+
+    public ConversionWebhookBuilderTests()
+    {
+        _crdBuilder = new Mock<ICrdBuilder>();
+        _componentRegistrar = new Mock<IComponentRegistrar>();
+        _conversionWebhookBuilder = new ConversionWebhookBuilder(_crdBuilder.Object, _componentRegistrar.Object,Mock.Of<ILogger<ConversionWebhookBuilder>>());
+    }
+
+    [Fact]
+    public void ConversionWebhookBuilderShouldSetConfigForLocalTunnel()
+    {
+        //Arrange
+        _componentRegistrar.Setup(c => c.ConversionRegistrations)
+            .Returns(ImmutableHashSet.Create(new IComponentRegistrar.ConversionRegistration(typeof(TestConversionWebhook),typeof(ConversionTestEntityV1Beta),typeof(ConversionTestEntityV1))));
+        _crdBuilder.Setup(s => s.BuildCrds()).Returns(new List<V1CustomResourceDefinition>()
+        {
+            new (){
+                Spec = new V1CustomResourceDefinitionSpec(){
+                    Group = "kubeops.test.dev",
+                    Versions = new List<V1CustomResourceDefinitionVersion>()
+            {
+                new ("v1beta1", true, false),
+                new ("v1", true, true),
+            }}},
+        });
+        WebhookConfig config = new("test", "https://localhost:5001/", null, null);
+        //Act
+        var result = _conversionWebhookBuilder.BuildWebhookConfiguration(config, true).ToList();
+        //Assert
+        Assert.Equal("Webhook",result.First().Spec.Conversion.Strategy);
+        Assert.Equal("https://localhost:5001/convert",result.First().Spec.Conversion.Webhook.ClientConfig.Url);
+        Assert.Equal("v1",result.First().Spec.Conversion.Webhook.ConversionReviewVersions.First());
+    }
+
+    [Fact]
+    public void ConversionWebhookBuilderShouldReturnEmptyList()
+    {
+        //Arrange
+        _componentRegistrar.Setup(c => c.ConversionRegistrations)
+            .Returns(ImmutableHashSet<IComponentRegistrar.ConversionRegistration>.Empty);
+        _crdBuilder.Setup(s => s.BuildCrds()).Returns(new List<V1CustomResourceDefinition>()
+        {
+            new (){
+                Spec = new V1CustomResourceDefinitionSpec(){
+                    Group = "kubeops.test1.dev",
+                    Versions = new List<V1CustomResourceDefinitionVersion>()
+                    {
+                        new ("v1beta1", true, false),
+                        new ("v1", true, true),
+                    }}},
+        });
+        WebhookConfig config = new("test", "https://localhost:5001/", null, null);
+        //Act
+        var result = _conversionWebhookBuilder.BuildWebhookConfiguration(config, true).ToList();
+        //Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void ConversionWebhookBuilderShouldSetConfig()
+    {
+        //Arrange
+        _componentRegistrar.Setup(c => c.ConversionRegistrations)
+            .Returns(ImmutableHashSet.Create(new IComponentRegistrar.ConversionRegistration(typeof(TestConversionWebhook),typeof(ConversionTestEntityV1Beta),typeof(ConversionTestEntityV1))));
+        _crdBuilder.Setup(s => s.BuildCrds()).Returns(new List<V1CustomResourceDefinition>()
+        {
+            new (){
+                Spec = new V1CustomResourceDefinitionSpec(){
+                    Group = "kubeops.test.dev",
+                    Versions = new List<V1CustomResourceDefinitionVersion>()
+                    {
+                        new ("v1beta1", true, false),
+                        new ("v1", true, true),
+                    }}},
+        });
+        var bundle = new[] { byte.MinValue };
+        WebhookConfig config = new("test", null, bundle, new Admissionregistrationv1ServiceReference("testService", "default", "/convert", 5000));
+        //Act
+        var result = _conversionWebhookBuilder.BuildWebhookConfiguration(config, false).ToList();
+        //Assert
+        Assert.Equal("Webhook",result.First().Spec.Conversion.Strategy);
+        Assert.Null(result.First().Spec.Conversion.Webhook.ClientConfig.Url);
+        Assert.Equal("v1",result.First().Spec.Conversion.Webhook.ConversionReviewVersions.First());
+        Assert.Equal(5000,result.First().Spec.Conversion.Webhook.ClientConfig.Service.Port);
+        Assert.Equal(bundle,result.First().Spec.Conversion.Webhook.ClientConfig.CaBundle);
+        Assert.Equal("/convert",result.First().Spec.Conversion.Webhook.ClientConfig.Service.Path);
+        Assert.Equal("default",result.First().Spec.Conversion.Webhook.ClientConfig.Service.NamespaceProperty);
+    }
+}

--- a/tests/KubeOps.Test/Operator/Webhook/ConversionWebhook/ConversionWebhookInstallerTests.cs
+++ b/tests/KubeOps.Test/Operator/Webhook/ConversionWebhook/ConversionWebhookInstallerTests.cs
@@ -1,0 +1,72 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using DotnetKubernetesClient;
+using k8s;
+using k8s.Models;
+using KubeOps.Operator.Webhooks;
+using KubeOps.Operator.Webhooks.ConversionWebhook;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace KubeOps.Enhancements.Test;
+
+public class ConversionWebhookInstallerTests
+{
+    private readonly ConversionWebhookInstaller _conversionWebhookInstaller;
+    private readonly Mock<IConversionWebhookBuilder> _conversionWebhookBuilder;
+    private readonly Mock<IKubernetesClient> _kubernetesClient;
+    private readonly Mock<ILogger<ConversionWebhookInstaller>> _logger;
+
+    public ConversionWebhookInstallerTests()
+    {
+        _logger = new Mock<ILogger<ConversionWebhookInstaller>>();
+        _conversionWebhookBuilder = new Mock<IConversionWebhookBuilder>();
+        _kubernetesClient = new Mock<IKubernetesClient>();
+        _conversionWebhookInstaller = new ConversionWebhookInstaller(
+            _conversionWebhookBuilder.Object,
+            _kubernetesClient.Object,
+            _logger.Object);
+    }
+
+    [Fact]
+    public async Task InstallShouldNotCallClientIfNoCustomResourceDefenitionsReturned()
+    {
+        //Arrange
+        var config = new WebhookConfig("test", null, null, null);
+        _conversionWebhookBuilder.Setup(b => b.BuildWebhookConfiguration(config, false))
+            .Returns(new List<V1CustomResourceDefinition>());
+        //Act
+        await _conversionWebhookInstaller.InstallConversionWebhooks(config);
+        //Assert
+        _kubernetesClient.Verify(c=>c.Save(It.IsAny<IKubernetesObject<V1ObjectMeta>>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task InstallShouldCallClientOnceIfOneCrdIsFound()
+    {
+        //Arrange
+        var config = new WebhookConfig("test", null, null, null);
+        _conversionWebhookBuilder.Setup(b => b.BuildWebhookConfiguration(config, false))
+            .Returns(new List<V1CustomResourceDefinition>(){new(){Spec = new V1CustomResourceDefinitionSpec(){Names = new V1CustomResourceDefinitionNames("test","test")}}});
+        //Act
+        await _conversionWebhookInstaller.InstallConversionWebhooks(config);
+        //Assert
+        _kubernetesClient.Verify(c=>c.Save(It.IsAny<IKubernetesObject<V1ObjectMeta>>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task InstallShouldCallClientTwiceIfTwoCrdAreFound()
+    {
+        //Arrange
+        var config = new WebhookConfig("test", null, null, null);
+        _conversionWebhookBuilder.Setup(b => b.BuildWebhookConfiguration(config, false))
+            .Returns(new List<V1CustomResourceDefinition>(){new(){Spec = new V1CustomResourceDefinitionSpec(){Names = new V1CustomResourceDefinitionNames("test","test")}}, new(){Spec = new V1CustomResourceDefinitionSpec(){Names = new V1CustomResourceDefinitionNames("test","test")}}});
+        //Act
+        await _conversionWebhookInstaller.InstallConversionWebhooks(config);
+        //Assert
+        _kubernetesClient.Verify(c=>c.Save(It.IsAny<IKubernetesObject<V1ObjectMeta>>()), Times.Exactly(2));
+    }
+
+
+}

--- a/tests/KubeOps.Test/Operator/Webhook/ConversionWebhook/CustomEntityDefinitionExtensionMethodsTests.cs
+++ b/tests/KubeOps.Test/Operator/Webhook/ConversionWebhook/CustomEntityDefinitionExtensionMethodsTests.cs
@@ -1,0 +1,46 @@
+﻿using DotnetKubernetesClient.Entities;
+using KubeOps.Operator.Entities.Extensions;
+using Xunit;
+
+namespace KubeOps.Test.Operator.Webhook.ConversionWebhook;
+
+public class CustomEntityDefinitionExtensionMethodsTests
+{
+    [Fact]
+    public void ShouldAddNamespaceToName()
+    {
+        //Arrange
+        var customEntityDefinition = new CustomEntityDefinition("test", "tests", "test.group", "v1", "test", "test", EntityScope.Namespaced);
+
+        //Act
+        var namespacedName = customEntityDefinition.GroupVersion();
+        //Assert
+        Assert.Equal("test.group/v1", namespacedName);
+    }
+
+    [Fact]
+    public void ShouldAddEmptyNamespaceToName()
+    {
+        //Arrange
+        var customEntityDefinition = new CustomEntityDefinition("test", "tests", "", "v1", "test", "test", EntityScope.Namespaced);
+        //Act
+        var namespacedName = customEntityDefinition.GroupVersion();
+
+        //Assert
+        Assert.Equal("/v1", namespacedName);
+    }
+
+    [Fact]
+    public void ShouldAddNamespaceToEmptyName()
+    {
+        //Arrange
+        var customEntityDefinition = new CustomEntityDefinition("test", "tests", "test.group", "", "test", "test", EntityScope.Namespaced);
+
+        //Act
+        var namespacedName = customEntityDefinition.GroupVersion();
+
+        //Assert
+        Assert.Equal("test.group/", namespacedName);
+    }
+
+}

--- a/tests/KubeOps.Test/TestEntities/TestConversionWebhook.cs
+++ b/tests/KubeOps.Test/TestEntities/TestConversionWebhook.cs
@@ -1,0 +1,11 @@
+﻿using KubeOps.Operator.Webhooks.ConversionWebhook;
+
+namespace KubeOps.Test.TestEntities;
+
+public class TestConversionWebhook : IConversionWebhook<ConversionTestEntityV1Beta, ConversionTestEntityV1>
+{
+    public ConversionTestEntityV1 Convert(ConversionTestEntityV1Beta customResourceInput)
+    {
+        return new ConversionTestEntityV1();
+    }
+}

--- a/tests/KubeOps.Test/TestEntities/TestEntity.cs
+++ b/tests/KubeOps.Test/TestEntities/TestEntity.cs
@@ -1,0 +1,44 @@
+﻿using System.Runtime.CompilerServices;
+using k8s.Models;
+using KubeOps.Operator.Entities;
+
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]
+namespace KubeOps.Test.TestEntities;
+
+[KubernetesEntity(Group = "kubeops.test.dev", ApiVersion = "v1beta1", Kind = "Car")]
+public class ConversionTestEntityV1Beta : CustomKubernetesEntity<ConversionTestEntityV1Beta.TestEntitySpec, ConversionTestEntityV1Beta.TestEntityStatus>
+{
+    public class TestEntitySpec
+    {
+        public int CarId { get; set; }
+        public string CarType { get; set; } = string.Empty;
+        public string Color { get; set; } = string.Empty;
+        public string LeaseCompany { get; set; } = string.Empty;
+        public bool IsLeaseCar { get; set; }
+        public string Owner { get; set; } = string.Empty;
+    }
+
+    public class TestEntityStatus
+    {
+        public bool IsQueued { get; set; } = false;
+    }
+}
+
+[KubernetesEntity(Group = "kubeops.test.dev", ApiVersion = "v1", Kind = "Car")]
+public class ConversionTestEntityV1 : CustomKubernetesEntity<ConversionTestEntityV1.TestEntitySpec, ConversionTestEntityV1.TestEntityStatus>
+{
+    public class TestEntitySpec
+    {
+        public int CarId { get; set; }
+        public string CarType { get; set; } = string.Empty;
+        public string Color { get; set; } = string.Empty;
+        public string LeaseCompany { get; set; } = string.Empty;
+        public bool IsLeaseCar { get; set; }
+        public string Owner { get; set; } = string.Empty;
+    }
+
+    public class TestEntityStatus
+    {
+        public bool IsQueued { get; set; } = false;
+    }
+}

--- a/tests/KubeOps.TestOperator/Controller/TestController.cs
+++ b/tests/KubeOps.TestOperator/Controller/TestController.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using KubeOps.Operator.Controller;
 using KubeOps.Operator.Controller.Results;
 using KubeOps.Operator.Rbac;
@@ -18,11 +17,10 @@ public class TestController : IResourceController<V1TestEntity>
         _manager = manager;
     }
 
-    public async Task<ResourceControllerResult> ReconcileAsync(V1TestEntity entity)
+    public Task<ResourceControllerResult> ReconcileAsync(V1TestEntity entity)
     {
         _manager.Reconciled(entity);
-        await Task.Delay(5000);
-        return ResourceControllerResult.RequeueEvent(TimeSpan.FromSeconds(5));
+        return Task.FromResult<ResourceControllerResult>(null);
     }
 
     public Task StatusModifiedAsync(V1TestEntity entity)

--- a/tests/KubeOps.TestOperator/Controller/TestController.cs
+++ b/tests/KubeOps.TestOperator/Controller/TestController.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using KubeOps.Operator.Controller;
 using KubeOps.Operator.Controller.Results;
 using KubeOps.Operator.Rbac;
@@ -17,10 +18,11 @@ public class TestController : IResourceController<V1TestEntity>
         _manager = manager;
     }
 
-    public Task<ResourceControllerResult> ReconcileAsync(V1TestEntity entity)
+    public async Task<ResourceControllerResult> ReconcileAsync(V1TestEntity entity)
     {
         _manager.Reconciled(entity);
-        return Task.FromResult<ResourceControllerResult>(null);
+        await Task.Delay(5000);
+        return ResourceControllerResult.RequeueEvent(TimeSpan.FromSeconds(5));
     }
 
     public Task StatusModifiedAsync(V1TestEntity entity)

--- a/tests/KubeOps.TestOperator/Program.cs
+++ b/tests/KubeOps.TestOperator/Program.cs
@@ -1,20 +1,10 @@
-﻿using System.Threading.Tasks;
-using KubeOps.Operator;
+﻿using KubeOps.Operator;
+using KubeOps.TestOperator;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
 
-namespace KubeOps.TestOperator;
+static IHostBuilder CreateHostBuilder(string[] args) =>
+    Host.CreateDefaultBuilder(args)
+        .ConfigureWebHostDefaults(webBuilder => { webBuilder.UseStartup<Startup>(); });
 
-public class Program
-{
-    static IHostBuilder CreateHostBuilder(string[] args)
-    {
-        return Host.CreateDefaultBuilder(args)
-            .ConfigureWebHostDefaults(webBuilder => { webBuilder.UseStartup<Startup>(); });
-    }
-
-    public static async Task Main(string[] args)
-    {
-        await CreateHostBuilder(args).Build().RunOperatorAsync(args);
-    }
-}
+await CreateHostBuilder(args).Build().RunOperatorAsync(args);

--- a/tests/KubeOps.TestOperator/Startup.cs
+++ b/tests/KubeOps.TestOperator/Startup.cs
@@ -9,7 +9,7 @@ public class Startup
 {
     public void ConfigureServices(IServiceCollection services)
     {
-        services.AddKubernetesOperator(s => s.EnableLeaderElection = false); //.AddWebhookLocaltunnel();
+        services.AddKubernetesOperator(); //.AddWebhookLocaltunnel();
         services.AddTransient<IManager, TestManager.TestManager>();
     }
 

--- a/tests/KubeOps.TestOperator/Startup.cs
+++ b/tests/KubeOps.TestOperator/Startup.cs
@@ -9,7 +9,7 @@ public class Startup
 {
     public void ConfigureServices(IServiceCollection services)
     {
-        services.AddKubernetesOperator(); //.AddWebhookLocaltunnel();
+        services.AddKubernetesOperator(s => s.EnableLeaderElection = false); //.AddWebhookLocaltunnel();
         services.AddTransient<IManager, TestManager.TestManager>();
     }
 


### PR DESCRIPTION
I have implemented the feature to create conversion webhooks to resolve #137
As part of this implementation i have created integration tests. There must be a running Kubernetes cluster to run these integration tests. It would be possible to run these tests in a pipeline but that would probably cost money because of the Kubernetes cluster that is mandetory.

I also had to change the usage of AddWebhookLocaltunnel because i ran into a problem where the reconcile of a given custom resource stops when the custom resource definition gets updated in the creation of the Localtunnel. Thats why i thought it would be a good idea to wait for the LocalTunnel to be created before starting the controllers. I made this possible by changing the way you add the localtunnel.
Instead of
`services.AddKubernetesOperator().AddWebhookLocaltunnel();`
you simple use 
`services.AddKubernetesOperator(s => settings.UseLocalTunnel());`

I'm really curious what you think about the implementation of this feature

I understand that this is a pretty big pull request so take your time and dont hesitate to ask me any questions for clarification