### PR TITLE
fix: Incorrect service lifetimes for controller resolution

### DIFF
--- a/src/KubeOps/Operator/Builder/OperatorBuilder.cs
+++ b/src/KubeOps/Operator/Builder/OperatorBuilder.cs
@@ -173,13 +173,18 @@ internal class OperatorBuilder : IOperatorBuilder
 
         Services.AddSingleton(_ => _componentRegistrar);
 
-        Services.AddTransient<IControllerInstanceBuilder, ControllerInstanceBuilder>();
-        Services.AddTransient(
-            s => (Func<IComponentRegistrar.ControllerRegistration, IManagedResourceController>)(r =>
-                (IManagedResourceController)ActivatorUtilities.CreateInstance(
-                    s,
-                    typeof(ManagedResourceController<>).MakeGenericType(r.EntityType),
-                    r)));
+        Services.AddSingleton<IControllerInstanceBuilder, ControllerInstanceBuilder>();
+        Services.AddSingleton<IControllerInstanceBuilder.ControllerFactory>(
+            (parent, registration) =>
+            {
+                var childScope = parent.CreateScope();
+                var controller = (IManagedResourceController)ActivatorUtilities.CreateInstance(
+                    childScope.ServiceProvider,
+                    typeof(ManagedResourceController<>).MakeGenericType(registration.EntityType),
+                    registration);
+
+                return new ScopedResourceController(childScope, controller);
+            });
 
         Services.AddTransient<IFinalizerInstanceBuilder, FinalizerInstanceBuilder>();
 

--- a/src/KubeOps/Operator/Controller/IControllerInstanceBuilder.cs
+++ b/src/KubeOps/Operator/Controller/IControllerInstanceBuilder.cs
@@ -1,13 +1,17 @@
+using System;
 using System.Collections.Generic;
 using k8s;
 using k8s.Models;
+using KubeOps.Operator.Builder;
 
 namespace KubeOps.Operator.Controller;
 
 internal interface IControllerInstanceBuilder
 {
-    public IEnumerable<IManagedResourceController> BuildControllers();
+    public delegate ScopedResourceController ControllerFactory(IServiceProvider parent, IComponentRegistrar.ControllerRegistration controllerRegistration);
 
-    public IEnumerable<IManagedResourceController> BuildControllers<TEntity>()
+    public IEnumerable<ScopedResourceController> BuildControllers();
+
+    public IEnumerable<ScopedResourceController> BuildControllers<TEntity>()
         where TEntity : IKubernetesObject<V1ObjectMeta>;
 }

--- a/src/KubeOps/Operator/Controller/IManagedResourceController.cs
+++ b/src/KubeOps/Operator/Controller/IManagedResourceController.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
+using KubeOps.Operator.Builder;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace KubeOps.Operator.Controller;
 

--- a/src/KubeOps/Operator/Controller/ScopedResourceController.cs
+++ b/src/KubeOps/Operator/Controller/ScopedResourceController.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace KubeOps.Operator.Controller;
+
+internal class ScopedResourceController : IManagedResourceController
+{
+    private readonly IDisposable _scope;
+    private readonly IManagedResourceController _controller;
+
+    public ScopedResourceController(IDisposable scope, IManagedResourceController controller)
+    {
+        _scope = scope;
+        _controller = controller;
+    }
+
+    public void Dispose() => _scope.Dispose();
+
+    public async Task StartAsync() => await _controller.StartAsync();
+
+    public async Task StopAsync() => await _controller.StopAsync();
+}


### PR DESCRIPTION
This resolves #450, confirmed by @rcm-steve-horne.

The bulk of the change is constructing a lifetime scope around each `IManagedResourceController`.