### PR TITLE
Required spec attribute

### DIFF
--- a/src/KubeOps/Operator/Entities/Annotations/RequiredSpecAttribute.cs
+++ b/src/KubeOps/Operator/Entities/Annotations/RequiredSpecAttribute.cs
@@ -1,0 +1,9 @@
+namespace KubeOps.Operator.Entities.Annotations;
+
+/// <summary>
+/// Allows to mark Entity specification as required.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class)]
+public class RequiredSpecAttribute : Attribute
+{
+}

--- a/src/KubeOps/Operator/Entities/Extensions/EntityToCrdExtensions.cs
+++ b/src/KubeOps/Operator/Entities/Extensions/EntityToCrdExtensions.cs
@@ -365,6 +365,11 @@ internal static class EntityToCrdExtensions
                         prop.GetCustomAttribute<IgnorePropertyAttribute>() == null)
             .Select(GetPropertyName)
             .ToList();
+        if (jsonPath == string.Empty && type.GetCustomAttribute<RequiredSpecAttribute>() != null)
+        {
+            props.Required.Add(typeof(CustomKubernetesEntity<>).GetProperties()[0].Name.ToLowerInvariant());
+        }
+
         if (props.Required.Count == 0)
         {
             props.Required = null;

--- a/tests/KubeOps.Test/Operator/Entities/CrdGeneration.Test.cs
+++ b/tests/KubeOps.Test/Operator/Entities/CrdGeneration.Test.cs
@@ -462,6 +462,14 @@ public class CrdGenerationTest
     }
 
     [Fact]
+    public void Should_Correctly_Use_Required_Spec_Attribute()
+    {
+        var clusterCrd = _testClusterSpecEntity.CreateCrd();
+
+        clusterCrd.Spec.Versions.First().Schema.OpenAPIV3Schema.Required.Should().Contain("spec");
+    }
+
+    [Fact]
     public void Should_Not_Contain_Ignored_Property()
     {
         const string propertyName = nameof(TestSpecEntity.Spec.IgnoredProperty);

--- a/tests/KubeOps.Test/TestEntities/TestSpecEntity.cs
+++ b/tests/KubeOps.Test/TestEntities/TestSpecEntity.cs
@@ -157,6 +157,7 @@ public class TestSpecEntity : CustomKubernetesEntity<TestSpecEntitySpec>
 
 [KubernetesEntity(Group = "kubeops.test.dev", ApiVersion = "V1")]
 [EntityScope(EntityScope.Cluster)]
+[RequiredSpec]
 public class TestClusterSpecEntity : CustomKubernetesEntity<TestSpecEntitySpec>
 {
 }


### PR DESCRIPTION
This PR adds feature that is described in following issue #519

It adds new attribute `RequiredSpec`. This attribute marks whether CRD, which is generated from Entity, mark _spec_ object (`.spec` for CRD) as required. If attribute is present on Entity, `.spec` CRD object is marked as required. If attribute is not present _spec_, section is optional.

with optional _spec_ following CRD manifest will be valid:
```
apiVersion: kubeops.test.dev/v1
kind: myKindObject
metadata:
  name: device
spec: {}
```
```c#
public class Spec 
{
    [Required] public int Index { get; set; }
}
public class MyKindObject : CustomKubernetesEntity<Spec>
{}
```