### PR TITLE
ResourceWatcher reconnection fixes

### DIFF
--- a/src/KubeOps/Operator/Kubernetes/ResourceWatcher{TEntity}.cs
+++ b/src/KubeOps/Operator/Kubernetes/ResourceWatcher{TEntity}.cs
@@ -73,9 +73,9 @@ internal class ResourceWatcher<TEntity> : IDisposable, IResourceWatcher<TEntity>
         {
             _watchEvents.Dispose();
             _reconnectHandler.Dispose();
+            _reconnectSubscription.Dispose();
         }
 
-        _reconnectSubscription.Dispose();
         if (_cancellation?.IsCancellationRequested == false)
         {
             _cancellation.Cancel();

--- a/src/KubeOps/Operator/Kubernetes/ResourceWatcher{TEntity}.cs
+++ b/src/KubeOps/Operator/Kubernetes/ResourceWatcher{TEntity}.cs
@@ -194,8 +194,6 @@ internal class ResourceWatcher<TEntity> : IDisposable, IResourceWatcher<TEntity>
                 .Timer(TimeSpan.FromMinutes(1))
                 .FirstAsync()
                 .Subscribe(_ => _reconnectAttempts = 0);
-
-            _reconnectHandler.OnNext(backoff);
         }
         catch (Exception exception)
         {

--- a/src/KubeOps/Operator/Kubernetes/ResourceWatcher{TEntity}.cs
+++ b/src/KubeOps/Operator/Kubernetes/ResourceWatcher{TEntity}.cs
@@ -76,6 +76,8 @@ internal class ResourceWatcher<TEntity> : IDisposable, IResourceWatcher<TEntity>
             _reconnectSubscription.Dispose();
         }
 
+        _resetReconnectCounter?.Dispose();
+
         if (_cancellation?.IsCancellationRequested == false)
         {
             _cancellation.Cancel();

--- a/src/KubeOps/Operator/Kubernetes/ResourceWatcher{TEntity}.cs
+++ b/src/KubeOps/Operator/Kubernetes/ResourceWatcher{TEntity}.cs
@@ -75,7 +75,6 @@ internal class ResourceWatcher<TEntity> : IDisposable, IResourceWatcher<TEntity>
             _reconnectHandler.Dispose();
         }
 
-        _reconnectHandler.Dispose();
         _reconnectSubscription.Dispose();
         if (_cancellation?.IsCancellationRequested == false)
         {


### PR DESCRIPTION
Removed disposal of `_reconnectHandler` in `ResourceWatcher` which causes `ObjectDisposedException` after [leader reelections](https://github.com/buehler/dotnet-operator-sdk/blob/a2290ff9edc41bbbb3a7b47a13a00c99e469f8f9/src/KubeOps/Operator/Controller/ResourceControllerManager.cs#L45) and the watcher stops observing the resource. #522

The situation happens after a consecutive call to `StartAsync` after `StopAsync`:
```C#
await _watcher.StartAsync();

await _watcher.StopAsync();

await _watcher.StartAsync();
```

The `_reconnectHandler ` should be disposed only in the if statement of the Disposing method:
```C#
private void Disposing(bool fromStop)
{
        if (!fromStop)
        {
            _watchEvents.Dispose();
            _reconnectHandler.Dispose();
        }

        // _reconnectHandler.Dispose(); // this causes an error later on
        //...
}
```

Thx