### PR TITLE
Extracted IResourceWatcherMetrics interface for mocking in unit tests

### DIFF
--- a/src/KubeOps/Operator/Builder/OperatorBuilder.cs
+++ b/src/KubeOps/Operator/Builder/OperatorBuilder.cs
@@ -196,7 +196,7 @@ internal class OperatorBuilder : IOperatorBuilder
         Services.AddScoped(typeof(IEventQueue<>), typeof(EventQueue<>));
 
         // Support all the metrics
-        Services.AddSingleton(typeof(ResourceWatcherMetrics<>));
+        Services.AddSingleton(typeof(IResourceWatcherMetrics<>), typeof(ResourceWatcherMetrics<>));
         Services.AddSingleton(typeof(ResourceCacheMetrics<>));
         Services.AddSingleton(typeof(ResourceControllerMetrics<>));
 

--- a/src/KubeOps/Operator/DevOps/IResourceWatcherMetrics{TEntity}.cs
+++ b/src/KubeOps/Operator/DevOps/IResourceWatcherMetrics{TEntity}.cs
@@ -1,0 +1,21 @@
+﻿using k8s;
+using k8s.Models;
+using Prometheus;
+
+namespace KubeOps.Operator.DevOps;
+
+public interface IResourceWatcherMetrics<TEntity> : IResourceWatcherMetrics
+    where TEntity : IKubernetesObject<V1ObjectMeta>
+{
+}
+
+public interface IResourceWatcherMetrics
+{
+    IGauge Running { get; }
+
+    ICounter WatchedEvents { get; }
+
+    ICounter WatcherExceptions { get; }
+
+    ICounter WatcherClosed { get; }
+}

--- a/src/KubeOps/Operator/DevOps/IResourceWatcherMetrics{TEntity}.cs
+++ b/src/KubeOps/Operator/DevOps/IResourceWatcherMetrics{TEntity}.cs
@@ -4,12 +4,12 @@ using Prometheus;
 
 namespace KubeOps.Operator.DevOps;
 
-public interface IResourceWatcherMetrics<TEntity> : IResourceWatcherMetrics
+internal interface IResourceWatcherMetrics<TEntity> : IResourceWatcherMetrics
     where TEntity : IKubernetesObject<V1ObjectMeta>
 {
 }
 
-public interface IResourceWatcherMetrics
+internal interface IResourceWatcherMetrics
 {
     IGauge Running { get; }
 

--- a/src/KubeOps/Operator/DevOps/ResourceWatcherMetrics{TEntity}.cs
+++ b/src/KubeOps/Operator/DevOps/ResourceWatcherMetrics{TEntity}.cs
@@ -5,7 +5,7 @@ using Prometheus;
 
 namespace KubeOps.Operator.DevOps;
 
-internal class ResourceWatcherMetrics<TEntity>
+internal class ResourceWatcherMetrics<TEntity> : IResourceWatcherMetrics<TEntity>
     where TEntity : IKubernetesObject<V1ObjectMeta>
 {
     private static readonly string[] Labels = { "operator", "kind", "group", "version", "scope", };
@@ -44,11 +44,11 @@ internal class ResourceWatcherMetrics<TEntity>
             .WithLabels(labelValues);
     }
 
-    public Gauge.Child Running { get; }
+    public IGauge Running { get; }
 
-    public Counter.Child WatchedEvents { get; }
+    public ICounter WatchedEvents { get; }
 
-    public Counter.Child WatcherExceptions { get; }
+    public ICounter WatcherExceptions { get; }
 
-    public Counter.Child WatcherClosed { get; }
+    public ICounter WatcherClosed { get; }
 }

--- a/src/KubeOps/Operator/Kubernetes/ResourceWatcher{TEntity}.cs
+++ b/src/KubeOps/Operator/Kubernetes/ResourceWatcher{TEntity}.cs
@@ -17,7 +17,7 @@ internal class ResourceWatcher<TEntity> : IDisposable, IResourceWatcher<TEntity>
     private readonly Subject<WatchEvent> _watchEvents = new();
     private readonly IKubernetesClient _client;
     private readonly ILogger<ResourceWatcher<TEntity>> _logger;
-    private readonly ResourceWatcherMetrics<TEntity> _metrics;
+    private readonly IResourceWatcherMetrics<TEntity> _metrics;
     private readonly OperatorSettings _settings;
     private readonly Subject<TimeSpan> _reconnectHandler = new();
     private readonly IDisposable _reconnectSubscription;
@@ -30,7 +30,7 @@ internal class ResourceWatcher<TEntity> : IDisposable, IResourceWatcher<TEntity>
     public ResourceWatcher(
         IKubernetesClient client,
         ILogger<ResourceWatcher<TEntity>> logger,
-        ResourceWatcherMetrics<TEntity> metrics,
+        IResourceWatcherMetrics<TEntity> metrics,
         OperatorSettings settings)
     {
         _client = client;

--- a/tests/KubeOps.Test/Operator/Kubernetes/ResourceWatcher{TEntity}.Test.cs
+++ b/tests/KubeOps.Test/Operator/Kubernetes/ResourceWatcher{TEntity}.Test.cs
@@ -1,0 +1,42 @@
+﻿using k8s;
+using k8s.Models;
+using KubeOps.KubernetesClient;
+using KubeOps.Operator;
+using KubeOps.Operator.DevOps;
+using KubeOps.Operator.Kubernetes;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Prometheus;
+using Xunit;
+
+namespace KubeOps.Test.Operator.Kubernetes;
+
+public class ResourceWatcherTest
+{
+    [KubernetesEntity]
+    public class TestResource : IKubernetesObject<V1ObjectMeta>
+    {
+        public string ApiVersion { get; set; } = null!;
+        public string Kind { get; set; } = null!;
+        public V1ObjectMeta Metadata { get; set; } = null!;
+    }
+
+    private readonly Mock<IKubernetesClient> _client = new();
+    private readonly Mock<IResourceWatcherMetrics<TestResource>> _metrics = new();
+
+    [Fact]
+    public async Task Should_Not_Dispose_Reconnect_Subject_Or_Throw_Exception_After_Restarts()
+    {
+        var settings = new OperatorSettings();
+
+        _metrics.Setup(c => c.Running).Returns(Mock.Of<IGauge>());
+
+        using var resourceWatcher = new ResourceWatcher<TestResource>(_client.Object, new NullLogger<ResourceWatcher<TestResource>>(), _metrics.Object, settings);
+
+        await resourceWatcher.StartAsync();
+
+        await resourceWatcher.StopAsync();
+
+        await resourceWatcher.StartAsync();
+    }
+}


### PR DESCRIPTION
This PR enables testability for the `ResourceWatcher<TEntity>` class see also #523 by extracting a new interface `IResourceWatcherMetrics<TEntity>`.