### PR TITLE
Improved ResourceWatcher restart unit test

### DIFF
--- a/src/KubeOps/Operator/Kubernetes/ResourceWatcher{TEntity}.cs
+++ b/src/KubeOps/Operator/Kubernetes/ResourceWatcher{TEntity}.cs
@@ -40,7 +40,7 @@ internal class ResourceWatcher<TEntity> : IDisposable, IResourceWatcher<TEntity>
         _settings = settings;
         _reconnectSubscription =
             _reconnectHandler
-                .Select(c => Observable.Timer(c, TimeBasedScheduler))
+                .Select(backoff => Observable.Timer(backoff, TimeBasedScheduler))
                 .Switch()
                 .Retry()
                 .Subscribe(async _ => await WatchResource(), error => _logger.LogError(error, $"There was an error while restarting the resource watcher {typeof(TEntity)}"));

--- a/tests/KubeOps.Test/KubeOps.Test.csproj
+++ b/tests/KubeOps.Test/KubeOps.Test.csproj
@@ -3,6 +3,10 @@
   <Import Project="..\..\config\CommonTests.targets" />
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Reactive.Testing" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\KubeOps.Testing\KubeOps.Testing.csproj" />
     <ProjectReference Include="..\..\src\KubeOps\KubeOps.csproj" />
     <ProjectReference Include="..\KubeOps.TestOperator\KubeOps.TestOperator.csproj" />

--- a/tests/KubeOps.Test/Operator/Kubernetes/ResourceWatcher{TEntity}.Test.cs
+++ b/tests/KubeOps.Test/Operator/Kubernetes/ResourceWatcher{TEntity}.Test.cs
@@ -69,15 +69,7 @@ public class ResourceWatcherTest
 
         testScheduler.AdvanceBy(backoff.Add(TimeSpan.FromSeconds(1)).Ticks);
 
-        _client.Verify(
-            c => c.Watch(
-                It.IsAny<TimeSpan>(),
-                It.IsAny<Action<WatchEventType, TestResource>>(),
-                It.IsAny<Action<Exception>?>(),
-                It.IsAny<Action>(),
-                null,
-                It.IsAny<CancellationToken>(),
-                It.IsAny<string?>()), Times.Exactly(2));
+        VerifyWatch(2);
     }
 
     [Fact]
@@ -113,15 +105,7 @@ public class ResourceWatcherTest
 
         resourceWatcher.WatchEvents.Should().NotBeNull();
 
-        _client.Verify(
-            c => c.Watch(
-                It.IsAny<TimeSpan>(),
-                It.IsAny<Action<WatchEventType, TestResource>>(),
-                It.IsAny<Action<Exception>?>(),
-                It.IsAny<Action>(),
-                null,
-                It.IsAny<CancellationToken>(),
-                It.IsAny<string?>()), Times.Exactly(2));
+        VerifyWatch(2);
     }
 
     [Fact]
@@ -160,7 +144,7 @@ public class ResourceWatcherTest
 
         await resourceWatcher.StartAsync();
 
-        var resource = new TestResource()
+        var resource = new TestResource
         {
             Metadata = new()
         };
@@ -198,8 +182,11 @@ public class ResourceWatcherTest
 
         onClose?.Invoke();
 
-        resourceWatcher.WatchEvents.Should().NotBeNull();
+        VerifyWatch(2);
+    }
 
+    private void VerifyWatch(int callTime)
+    {
         _client.Verify(
             c => c.Watch(
                 It.IsAny<TimeSpan>(),
@@ -208,7 +195,7 @@ public class ResourceWatcherTest
                 It.IsAny<Action>(),
                 null,
                 It.IsAny<CancellationToken>(),
-                It.IsAny<string?>()), Times.Exactly(2));
+                It.IsAny<string?>()), Times.Exactly(callTime));
     }
 
     private static Watcher<TestResource> CreateFakeWatcher()

--- a/tests/KubeOps.Test/Operator/Kubernetes/ResourceWatcher{TEntity}.Test.cs
+++ b/tests/KubeOps.Test/Operator/Kubernetes/ResourceWatcher{TEntity}.Test.cs
@@ -173,13 +173,12 @@ public class ResourceWatcherTest
         watchEvent.Resource.Should().BeEquivalentTo(resource);
     }
 
-
     [Fact]
     public async Task Should_Restart_Watcher_On_Close()
     {
         var settings = new OperatorSettings();
 
-        Action onClose = null!;
+        Action? onClose = null;
 
         _client.Setup(c => c.Watch(It.IsAny<TimeSpan>(), It.IsAny<Action<WatchEventType, TestResource>>(), It.IsAny<Action<Exception>?>(), It.IsAny<Action>(), null, It.IsAny<CancellationToken>(), It.IsAny<string?>()))
             .Callback<TimeSpan, Action<WatchEventType, TestResource>, Action<Exception>?, Action?, string?, CancellationToken, string?>(
@@ -197,7 +196,7 @@ public class ResourceWatcherTest
 
         await resourceWatcher.StartAsync();
 
-        onClose();
+        onClose?.Invoke();
 
         resourceWatcher.WatchEvents.Should().NotBeNull();
 


### PR DESCRIPTION
I apologize that I'm providing the tests in 2 phases for the `ResourceWatcher`, but it was "nontrivial" to write them due to `k8s.Watcher` etc.

Thank you! 

#482 #522 #523 #526