### PR TITLE
fixed AdmissionResponse.PatchType to an optional value

### DIFF
--- a/src/KubeOps/Operator/Webhooks/AdmissionResponse.cs
+++ b/src/KubeOps/Operator/Webhooks/AdmissionResponse.cs
@@ -19,7 +19,7 @@ internal sealed class AdmissionResponse
     public string[] Warnings { get; init; } = Array.Empty<string>();
 
     [JsonPropertyName("patchType")]
-    public string PatchType { get; set; } = JsonPatch;
+    public string? PatchType { get; set; }
 
     [JsonPropertyName("patch")]
     public string? Patch { get; set; }


### PR DESCRIPTION
This PR changes back the AdmissionResponse.PatchType to an optional value #536 since validation web hooks cannot contain a PatchType.

Fixes #536 