### PR TITLE
CLI commands link fix

### DIFF
--- a/src/KubeOps/README.md
+++ b/src/KubeOps/README.md
@@ -73,7 +73,7 @@ public static class Program
 ```
 
 This adds the default commands (like run and the code generators) to your app.
-The commands are documentated under the [CLI Commands](#commands.md) section.
+The commands are documentated under the [CLI Commands](#commands) section.
 
 > Technically you don't need to replace the function,
 > but if you don't, the other commands like yaml generation

--- a/src/KubeOps/README.md
+++ b/src/KubeOps/README.md
@@ -73,7 +73,7 @@ public static class Program
 ```
 
 This adds the default commands (like run and the code generators) to your app.
-The commands are documentated under the [CLI Commands](./commands.md) section.
+The commands are documentated under the [CLI Commands](#commands.md) section.
 
 > Technically you don't need to replace the function,
 > but if you don't, the other commands like yaml generation


### PR DESCRIPTION
This PR fixes a "Page not found exception" for the CLI commands in the "Update Entrypoint" section of KubeOps readme.md.
[CLI Commands](https://github.com/buehler/dotnet-operator-sdk/blob/master/src/KubeOps/commands.md) link.