### PR TITLE
fix: use pre-downloaded binaries for cfssl

### DIFF
--- a/src/KubeOps.Testing/KubernetesOperatorFactory.cs
+++ b/src/KubeOps.Testing/KubernetesOperatorFactory.cs
@@ -42,6 +42,13 @@ public class KubernetesOperatorFactory<TTestStartup> : WebApplicationFactory<TTe
         return this;
     }
 
+    public IManagedResourceController GetController<TEntity>()
+        where TEntity : IKubernetesObject<V1ObjectMeta> =>
+            Services
+            .GetRequiredService<IControllerInstanceBuilder>()
+            .BuildControllers<TEntity>()
+            .First();
+
     /// <summary>
     /// Start the server.
     /// </summary>

--- a/src/KubeOps/Operator/Commands/CommandHelpers/CertificateGenerator.cs
+++ b/src/KubeOps/Operator/Commands/CommandHelpers/CertificateGenerator.cs
@@ -1,11 +1,10 @@
 ﻿using System.Diagnostics;
-using System.Runtime.InteropServices;
-using McMaster.Extensions.CommandLineUtils;
 
 namespace KubeOps.Operator.Commands.CommandHelpers;
 
 internal class CertificateGenerator : IDisposable
 {
+    /* Suggested URLs for downloading the executables into the docker image
     private const string CfsslUrlWindows =
         "https://github.com/cloudflare/cfssl/releases/download/v1.5.0/cfssl_1.5.0_windows_amd64.exe";
 
@@ -23,6 +22,7 @@ internal class CertificateGenerator : IDisposable
 
     private const string CfsslJsonUrlMacOs =
         "https://github.com/cloudflare/cfssl/releases/download/v1.5.0/cfssljson_1.5.0_darwin_amd64";
+    */
 
     private const string CaConfig =
         @"{""signing"":{""default"":{""expiry"":""43800h""},""profiles"":{""server"":{""expiry"":""43800h"",""usages"":[""signing"",""key encipherment"",""server auth""]}}}}";
@@ -30,12 +30,13 @@ internal class CertificateGenerator : IDisposable
     private const string CaCsr =
         @"{""CN"":""Operator Root CA"",""key"":{""algo"":""rsa"",""size"":2048},""names"":[{""C"":""DEV"",""L"":""Kubernetes"",""O"":""Kubernetes Operator""}]}";
 
+    private const string Cfssl = "/operator/cfssl";
+    private const string Cfssljson = "/operator/cfssljson"; // TODO: maybe read this from configuration? (seems like an overkill though)
+
     private readonly TextWriter _appOut;
     private readonly string _tempDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
 
     private bool _initialized;
-    private string? _cfssl;
-    private string? _cfssljson;
     private string? _caconfig;
     private string? _cacsr;
     private string? _servercsr;
@@ -45,16 +46,12 @@ internal class CertificateGenerator : IDisposable
         _appOut = appOut;
     }
 
-    private static string ShellExecutor => RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-        ? "cmd.exe"
-        : "/bin/sh";
-
     public void Dispose()
     {
         Delete(_caconfig);
         Delete(_cacsr);
-        Delete(_cfssl);
-        Delete(_cfssljson);
+        Delete(Cfssl);
+        Delete(Cfssljson);
         Delete(_servercsr);
     }
 
@@ -70,18 +67,8 @@ internal class CertificateGenerator : IDisposable
 
         await _appOut.WriteLineAsync($@"Generating certificates to ""{outputFolder}"".");
         await _appOut.WriteLineAsync("Generating CA certificate.");
-        await ExecuteProcess(
-            new Process
-            {
-                StartInfo = new ProcessStartInfo
-                {
-                    WorkingDirectory = outputFolder,
-                    FileName = ShellExecutor,
-                    Arguments = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-                        ? $"/c {_cfssl} gencert -initca {_cacsr} | {_cfssljson} -bare ca -"
-                        : $@"-c ""{_cfssl} gencert -initca {_cacsr} | {_cfssljson} -bare ca -""",
-                },
-            });
+
+        await GenCertAsync($"-initca {_cacsr}", outputFolder);
 
         await ListDir(outputFolder);
     }
@@ -110,32 +97,48 @@ internal class CertificateGenerator : IDisposable
 
         await _appOut.WriteLineAsync(
             $@"Generating server certificate for ""{name}"" in namespace ""{@namespace}"".");
-        await ExecuteProcess(
-            new Process
-            {
-                StartInfo = new ProcessStartInfo
-                {
-                    WorkingDirectory = outputFolder,
-                    FileName = ShellExecutor,
-                    Arguments = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-                        ? $"/c {_cfssl} gencert -ca=file:{caPath.Replace('\\', '/')} -ca-key=file:{caKeyPath.Replace('\\', '/')} -config={_caconfig} -profile=server {_servercsr} | {_cfssljson} -bare server -"
-                        : $@"-c ""{_cfssl} gencert -ca={caPath} -ca-key={caKeyPath} -config={_caconfig} -profile=server {_servercsr} | {_cfssljson} -bare server -""",
-                },
-            });
-
+        var arguments =
+            $"-ca=file:{caPath.Replace('\\', '/')} -ca-key=file:{caKeyPath.Replace('\\', '/')} -config={_caconfig} -profile=server {_servercsr}";
+        await GenCertAsync(arguments, outputFolder);
         await ListDir(outputFolder);
     }
 
     private static string ServerCsr(params string[] serverNames) =>
         $@"{{""CN"":""Operator Service"",""hosts"":[""{string.Join(@""",""", serverNames)}""],""key"":{{""algo"":""ecdsa"",""size"":256}},""names"":[{{""C"":""DEV"",""L"":""Kubernetes""}}]}}";
 
-    private static Task ExecuteProcess(Process process)
-        => Task.Run(
-            () =>
-            {
-                process.Start();
-                process.WaitForExit(2000);
-            });
+    private static async Task GenCertAsync(
+        string arguments,
+        string outputFolder,
+        CancellationToken cancellationToken = default)
+    {
+        var genCertPsi = new ProcessStartInfo
+        {
+            WorkingDirectory = outputFolder,
+            FileName = Cfssl,
+            Arguments = $"gencert {arguments}",
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+        };
+        var writeJsonPsi = new ProcessStartInfo
+        {
+            WorkingDirectory = outputFolder,
+            FileName = Cfssljson,
+            Arguments = "-bare ca -",
+            RedirectStandardInput = true,
+            UseShellExecute = false,
+        };
+        using var genCert = new Process { StartInfo = genCertPsi };
+        using var writeJson = new Process { StartInfo = writeJsonPsi };
+
+        genCert.Start();
+        await genCert.WaitForExitAsync(cancellationToken);
+
+        writeJson.Start();
+        await writeJson.StandardInput.WriteAsync(await genCert.StandardOutput.ReadToEndAsync());
+        await writeJson.StandardInput.FlushAsync();
+        writeJson.StandardInput.Close();
+        await writeJson.WaitForExitAsync(cancellationToken);
+    }
 
     private static void Delete(string? file)
     {
@@ -153,63 +156,13 @@ internal class CertificateGenerator : IDisposable
     private async Task PrepareExecutables()
     {
         Directory.CreateDirectory(_tempDirectory);
-        _cfssl = Path.Join(_tempDirectory, Path.GetRandomFileName());
-        _cfssljson = Path.Join(_tempDirectory, Path.GetRandomFileName());
         _caconfig = Path.Join(_tempDirectory, Path.GetRandomFileName());
         _cacsr = Path.Join(_tempDirectory, Path.GetRandomFileName());
 
-        using (var client = new HttpClient())
-        await using (var cfsslStream = new FileStream(_cfssl, FileMode.CreateNew))
-        await using (var cfsslJsonStream = new FileStream(_cfssljson, FileMode.CreateNew))
-        await using (var caConfigStream = new StreamWriter(new FileStream(_caconfig, FileMode.CreateNew)))
-        await using (var caCsrStream = new StreamWriter(new FileStream(_cacsr, FileMode.CreateNew)))
-        {
-            await caConfigStream.WriteLineAsync(CaConfig);
-            await caCsrStream.WriteLineAsync(CaCsr);
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                await _appOut.WriteLineAsync("Download cfssl / cfssljson for windows.");
-                await using var cfsslDl = await client.GetStreamAsync(CfsslUrlWindows);
-                await using var cfsslJsonDl = await client.GetStreamAsync(CfsslJsonUrlWindows);
-
-                await cfsslDl.CopyToAsync(cfsslStream);
-                await cfsslJsonDl.CopyToAsync(cfsslJsonStream);
-            }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                await _appOut.WriteLineAsync("Download cfssl / cfssljson for linux.");
-                await using var cfsslDl = await client.GetStreamAsync(CfsslUrlLinux);
-                await using var cfsslJsonDl = await client.GetStreamAsync(CfsslJsonUrlLinux);
-
-                await cfsslDl.CopyToAsync(cfsslStream);
-                await cfsslJsonDl.CopyToAsync(cfsslJsonStream);
-            }
-            else
-            {
-                await _appOut.WriteLineAsync("Download cfssl / cfssljson for macos.");
-                await using var cfsslDl = await client.GetStreamAsync(CfsslUrlMacOs);
-                await using var cfsslJsonDl = await client.GetStreamAsync(CfsslJsonUrlMacOs);
-
-                await cfsslDl.CopyToAsync(cfsslStream);
-                await cfsslJsonDl.CopyToAsync(cfsslJsonStream);
-            }
-        }
-
-        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            await _appOut.WriteLineAsync("Make unix binaries executable.");
-            await ExecuteProcess(
-                new Process
-                {
-                    StartInfo = new ProcessStartInfo
-                    {
-                        FileName = "chmod",
-                        Arguments = ArgumentEscaper.EscapeAndConcatenate(
-                            new[] { "+x", _cfssl, _cfssljson }),
-                    },
-                });
-        }
+        await using var caConfigStream = new StreamWriter(new FileStream(_caconfig, FileMode.CreateNew));
+        await using var caCsrStream = new StreamWriter(new FileStream(_cacsr, FileMode.CreateNew));
+        await caConfigStream.WriteLineAsync(CaConfig);
+        await caCsrStream.WriteLineAsync(CaCsr);
     }
 
     private async Task ListDir(string directory)

--- a/src/KubeOps/Operator/Commands/Generators/DockerGenerator.cs
+++ b/src/KubeOps/Operator/Commands/Generators/DockerGenerator.cs
@@ -56,11 +56,13 @@ FROM mcr.microsoft.com/dotnet/sdk:{DotnetImageTag} as build
 WORKDIR /operator
 
 COPY ./ ./
+RUN curl -L -o cfssl https://github.com/cloudflare/cfssl/releases/download/v1.5.0/cfssl_1.5.0_linux_amd64
+RUN curl -L -o cfssljson https://github.com/cloudflare/cfssl/releases/download/v1.5.0/cfssljson_1.5.0_linux_amd64
+RUN chmod +x ./cfssl
+RUN chmod +x ./cfssljson
+RUN mkdir out
+RUN cp cfssl cfssljson out/
 RUN dotnet publish -c Release -o out {ProjectToBuild}
-RUN curl -L -o out/cfssl https://github.com/cloudflare/cfssl/releases/download/v1.5.0/cfssl_1.5.0_linux_amd64
-RUN curl -L -o out/cfssljson https://github.com/cloudflare/cfssl/releases/download/v1.5.0/cfssljson_1.5.0_linux_amd64
-RUN chmod +x out/cfssl
-RUN chmod +x out/cfssljson
 
 # The runner for the application
 FROM mcr.microsoft.com/dotnet/aspnet:{DotnetImageTag} as final

--- a/src/KubeOps/Operator/Commands/Generators/DockerGenerator.cs
+++ b/src/KubeOps/Operator/Commands/Generators/DockerGenerator.cs
@@ -57,6 +57,10 @@ WORKDIR /operator
 
 COPY ./ ./
 RUN dotnet publish -c Release -o out {ProjectToBuild}
+RUN curl -L -o out/cfssl https://github.com/cloudflare/cfssl/releases/download/v1.5.0/cfssl_1.5.0_linux_amd64
+RUN curl -L -o out/cfssljson https://github.com/cloudflare/cfssl/releases/download/v1.5.0/cfssljson_1.5.0_linux_amd64
+RUN chmod +x out/cfssl
+RUN chmod +x out/cfssljson
 
 # The runner for the application
 FROM mcr.microsoft.com/dotnet/aspnet:{DotnetImageTag} as final

--- a/src/KubeOps/Operator/Commands/Generators/OperatorGenerator.cs
+++ b/src/KubeOps/Operator/Commands/Generators/OperatorGenerator.cs
@@ -53,8 +53,8 @@ internal class OperatorGenerator : GeneratorBase
                                 {
                                     $"KESTREL__ENDPOINTS__HTTP__URL=http://0.0.0.0:{_settings.HttpPort}",
                                     $"KESTREL__ENDPOINTS__HTTPS__URL=https://0.0.0.0:{_settings.HttpsPort}",
-                                    "KESTREL__ENDPOINTS__HTTPS__CERTIFICATE__PATH=/certs/server.pem",
-                                    "KESTREL__ENDPOINTS__HTTPS__CERTIFICATE__KEYPATH=/certs/server-key.pem",
+                                    "KESTREL__ENDPOINTS__HTTPS__CERTIFICATE__PATH=/certs/ca.pem",
+                                    "KESTREL__ENDPOINTS__HTTPS__CERTIFICATE__KEYPATH=/certs/ca-key.pem",
                                 },
                             },
                         }
@@ -112,7 +112,7 @@ internal class OperatorGenerator : GeneratorBase
                                         {
                                             Image = "operator",
                                             Name = "webhook-installer",
-                                            Args = new[] { "webhooks", "install", },
+                                            Args = new[] { "webhooks", "install", "-r" },
                                             Env = new List<V1EnvVar>
                                             {
                                                 new()

--- a/src/KubeOps/Operator/Commands/Management/Webhooks/Install.cs
+++ b/src/KubeOps/Operator/Commands/Management/Webhooks/Install.cs
@@ -131,6 +131,7 @@ internal class Install
             if (existingItem != null)
             {
                 await app.Out.WriteLineAsync("Validator existed, updating.");
+                existingItem.Webhooks = validatorConfig.Webhooks;
                 await client.Update(existingItem);
             }
             else

--- a/src/KubeOps/Operator/Controller/IManagedResourceController.cs
+++ b/src/KubeOps/Operator/Controller/IManagedResourceController.cs
@@ -1,6 +1,6 @@
 ﻿namespace KubeOps.Operator.Controller;
 
-internal interface IManagedResourceController : IDisposable
+public interface IManagedResourceController : IDisposable
 {
     Task StartAsync();
 

--- a/tests/KubeOps.TestOperator.Test/TestController.Test.cs
+++ b/tests/KubeOps.TestOperator.Test/TestController.Test.cs
@@ -20,11 +20,7 @@ public class TestControllerTest : IClassFixture<KubernetesOperatorFactory<TestSt
     {
         _factory = factory.WithSolutionRelativeContentRoot("tests/KubeOps.TestOperator");
 
-        _controller = _factory.Services
-            .GetRequiredService<IControllerInstanceBuilder>()
-            .BuildControllers<V1TestEntity>()
-            .First();
-
+        _controller = _factory.GetController<V1TestEntity>();
         _managerMock = _factory.Services.GetRequiredService<Mock<IManager>>();
         _managerMock.Reset();
     }


### PR DESCRIPTION
This PR makes sure that the init pod will use pre-downloaded binaries, so that the operator can be deployed in offline scenarios. Also it no longer makes the assumption that binaries like `sh` and `chmod` exist in the docker image (a lot of hardened/ minimal images don't have shell on them). 

Other changes:
- modified `server.pem` and `server-key.pem` to `ca.pem` and `ca-key.pem` - AFAICT, these are the file names generated by cfssljson ; yes I know it's confusing but these are different than the input ones.
- passed additional argument "-r" to the init pod - we don't want it failing on subsequent deployments/ if a webhook already exists. 

Fixes #567.