### PR TITLE
fix: update mutating webhook configuration

### DIFF
--- a/src/KubeOps/Operator/Commands/Management/Webhooks/Install.cs
+++ b/src/KubeOps/Operator/Commands/Management/Webhooks/Install.cs
@@ -159,6 +159,7 @@ internal class Install
             if (existingItem != null)
             {
                 await app.Out.WriteLineAsync("Mutator existed, updating.");
+                existingItem.Webhooks = mutatorConfig.Webhooks;
                 await client.Update(existingItem);
             }
             else


### PR DESCRIPTION
Fixes mutating webhook configuration not being updated by the command `webhook install -r` when the object already exists.