### PR TITLE
fix: don't delete cfssl and cfssljson

### DIFF
--- a/src/KubeOps/Operator/Commands/CommandHelpers/CertificateGenerator.cs
+++ b/src/KubeOps/Operator/Commands/CommandHelpers/CertificateGenerator.cs
@@ -49,8 +49,6 @@ internal class CertificateGenerator : IDisposable
     {
         Delete(_caconfig);
         Delete(_cacsr);
-        Delete(_cfssl);
-        Delete(_cfssljson);
         Delete(_servercsr);
     }
 


### PR DESCRIPTION
With #568 these executables are no longer downloaded on demand, but rather predownloaded to the system.

When running dotnet build locally, it attempts to run `./cfssl` and `./cfssljson` from `/operator` or `$CFSSL_EXECUTABLES_PATH`. However, it deletes them after it's done.

Next time you try build again after cleaning the local dir it'll fail.