### PR TITLE
fix version command

### DIFF
--- a/src/KubeOps/Operator/Commands/RunOperator.cs
+++ b/src/KubeOps/Operator/Commands/RunOperator.cs
@@ -10,7 +10,7 @@ namespace KubeOps.Operator.Commands;
 [Subcommand(typeof(Install))]
 [Subcommand(typeof(Uninstall))]
 [Subcommand(typeof(Management.Webhooks.Webhooks))]
-[Subcommand(typeof(Version))]
+[Subcommand(typeof(Utilities.Version))]
 internal class RunOperator
 {
     private readonly IHost _host;


### PR DESCRIPTION
Because System is a global import, this Version class actually refers to [Version Class (System) | Microsoft Learn](https://learn.microsoft.com/en-us/dotnet/api/system.version?view=net-7.0).