### PR TITLE
Generate good help text instead of stack trace on unrecognized command

### DIFF
--- a/src/KubeOps/Operator/Commands/RunOperator.cs
+++ b/src/KubeOps/Operator/Commands/RunOperator.cs
@@ -10,7 +10,7 @@ namespace KubeOps.Operator.Commands;
 [Subcommand(typeof(Install))]
 [Subcommand(typeof(Uninstall))]
 [Subcommand(typeof(Management.Webhooks.Webhooks))]
-[Subcommand(typeof(Utilities.Version))]
+[Subcommand(typeof(Version))]
 internal class RunOperator
 {
     private readonly IHost _host;

--- a/src/KubeOps/Operator/Commands/RunOperator.cs
+++ b/src/KubeOps/Operator/Commands/RunOperator.cs
@@ -5,7 +5,7 @@ using McMaster.Extensions.CommandLineUtils;
 
 namespace KubeOps.Operator.Commands;
 
-[Command(Description = "Runs the operator.")]
+[Command(Description = "Runs the operator.", UsePagerForHelpText = true)]
 [Subcommand(typeof(Generator))]
 [Subcommand(typeof(Install))]
 [Subcommand(typeof(Uninstall))]

--- a/src/KubeOps/Operator/Commands/RunOperator.cs
+++ b/src/KubeOps/Operator/Commands/RunOperator.cs
@@ -10,7 +10,7 @@ namespace KubeOps.Operator.Commands;
 [Subcommand(typeof(Install))]
 [Subcommand(typeof(Uninstall))]
 [Subcommand(typeof(Management.Webhooks.Webhooks))]
-[Subcommand(typeof(Version))]
+[Subcommand(typeof(Utilities.Version))]
 internal class RunOperator
 {
     private readonly IHost _host;

--- a/src/KubeOps/Operator/HostExtensions.cs
+++ b/src/KubeOps/Operator/HostExtensions.cs
@@ -16,14 +16,23 @@ public static class HostExtensions
     /// <param name="host">The <see cref="IHost"/>.</param>
     /// <param name="args">Program arguments.</param>
     /// <returns>Async task with completion result.</returns>
-    public static Task<int> RunOperatorAsync(this IHost host, string[] args)
+    public static async Task<int> RunOperatorAsync(this IHost host, string[] args)
     {
         var app = new CommandLineApplication<RunOperator>();
         app
             .Conventions
             .UseDefaultConventions()
             .UseConstructorInjection(host.Services);
-
-        return app.ExecuteAsync(args);
+        try
+        {
+            return await app.ExecuteAsync(args);
+        }
+        catch (UnrecognizedCommandParsingException ex)
+        {
+            Console.WriteLine(ex.Message);
+            ex.Command.Description = null;
+            ex.Command.ShowHelp();
+            return 1;
+        }
     }
 }


### PR DESCRIPTION
So now it looks like this:
```
(base) PS E:\Git\github.com\stevefan1999-personal\dotnet-operator-sdk\src> dotnet run --project KubeOps.Play --framework net7.0 -- generator abcd
Building...
Specify --help for a list of available options and commands.
Unrecognized command or argument 'abcd'
Usage: KubeOps.Play generator [command] [options]

Options:
  -f|--format <FORMAT>    Determines the output format for the generator.
                          Allowed values are: Yaml, Json.
  -o|--out <OUTPUT_PATH>  The "root" path for the generator to put files in - if empty, prints to console.
  -?|-h|--help            Show help information.

Commands:
  crd                     Generates the needed CRD for kubernetes.
  docker                  Generates the docker file for building.
  installer               Generates kustomization yaml for the whole installation of the operator.
  operator                Generates the needed yamls to run the operator.
  rbac                    Generates the needed rbac roles for the operator.

Run 'generator [command] -?|-h|--help' for more information about a command.

```
Instead of this:
```
(base) PS E:\Git\github.com\stevefan1999-personal\dotnet-operator-sdk\src> dotnet run --project KubeOps.Play --framework net7.0 -- generator abcd 
Building...
E:\Git\github.com\stevefan1999-personal\dotnet-operator-sdk\src\KubeOps\Operator\HostExtensions.cs(33,13): warning SA1515: Single-line comment should be preceded by blank line (https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1515.md) [E:\Git\github
.com\stevefan1999-personal\dotnet-operator-sdk\src\KubeOps\KubeOps.csproj::TargetFramework=net7.0]
Specify --help for a list of available options and commands.
Unhandled exception. McMaster.Extensions.CommandLineUtils.UnrecognizedCommandParsingException: Unrecognized command or argument 'abcd'
   at McMaster.Extensions.CommandLineUtils.CommandLineProcessor.ProcessUnexpectedArg(String argTypeName, String argValue)
   at McMaster.Extensions.CommandLineUtils.CommandLineProcessor.ProcessCommandOrParameter(CommandOrParameterArgument arg)
   at McMaster.Extensions.CommandLineUtils.CommandLineProcessor.ProcessNext()
   at McMaster.Extensions.CommandLineUtils.CommandLineProcessor.Process()
   at McMaster.Extensions.CommandLineUtils.CommandLineApplication.Parse(String[] args)
   at McMaster.Extensions.CommandLineUtils.CommandLineApplication.ExecuteAsync(String[] args, CancellationToken cancellationToken)
   at KubeOps.Operator.HostExtensions.RunOperatorAsync(IHost host, String[] args) in E:\Git\github.com\stevefan1999-personal\dotnet-operator-sdk\src\KubeOps\Operator\HostExtensions.cs:line 28
   at Program.<Main>$(String[] args) in E:\Git\github.com\stevefan1999-personal\dotnet-operator-sdk\src\KubeOps.Play\Program.cs:line 10
   at Program.<Main>(String[] args)
```

The `Specify --help for a list of available options and commands` stuff is unfortunately non-removable.
https://github.com/natemcmaster/CommandLineUtils/blob/81199c7ec68367ea9612be55719dc1fe08f658da/src/CommandLineUtils/Internal/CommandLineProcessor.cs#L323