### PR TITLE
fix/feat: Add options for 'generator installer', remove unused -o/-f options from 'generator' base command help, and change some wording 

### DIFF
--- a/src/KubeOps/Operator/Commands/Generators/CrdGenerator.cs
+++ b/src/KubeOps/Operator/Commands/Generators/CrdGenerator.cs
@@ -7,7 +7,7 @@ using McMaster.Extensions.CommandLineUtils;
 namespace KubeOps.Operator.Commands.Generators;
 
 [Command("crd", "crds", Description = "Generates the needed CRD for kubernetes.")]
-internal class CrdGenerator : GeneratorBase
+internal class CrdGenerator : OutputBase
 {
     private readonly ICrdBuilder _crdBuilder;
 

--- a/src/KubeOps/Operator/Commands/Generators/DockerGenerator.cs
+++ b/src/KubeOps/Operator/Commands/Generators/DockerGenerator.cs
@@ -5,7 +5,7 @@ using McMaster.Extensions.CommandLineUtils;
 namespace KubeOps.Operator.Commands.Generators;
 
 [Command("docker", Description = "Generates the docker file for building.")]
-internal class DockerGenerator : GeneratorBase
+internal class DockerGenerator : OutputBase
 {
     private readonly OperatorSettings _settings;
     private readonly bool _hasWebhooks;

--- a/src/KubeOps/Operator/Commands/Generators/Generator.cs
+++ b/src/KubeOps/Operator/Commands/Generators/Generator.cs
@@ -8,7 +8,7 @@ namespace KubeOps.Operator.Commands.Generators;
 [Subcommand(typeof(InstallerGenerator))]
 [Subcommand(typeof(OperatorGenerator))]
 [Subcommand(typeof(RbacGenerator))]
-internal class Generator : GeneratorBase
+internal class Generator
 {
     public Task<int> OnExecuteAsync(CommandLineApplication app)
     {

--- a/src/KubeOps/Operator/Commands/Generators/InstallerGenerator.cs
+++ b/src/KubeOps/Operator/Commands/Generators/InstallerGenerator.cs
@@ -6,26 +6,26 @@ using McMaster.Extensions.CommandLineUtils;
 
 namespace KubeOps.Operator.Commands.Generators;
 
-[Command("installer", Description = "Generates kustomization yaml for the whole installation of the operator.")]
+[Command("installer", Description = "Generates kustomization YAML that uses the output from the other generator commands to create the entire operator.")]
 internal class InstallerGenerator : GeneratorBase
 {
     private readonly OperatorSettings _settings;
 
     public InstallerGenerator(OperatorSettings settings) => _settings = settings;
 
-    [Option("--crds-dir", Description = "The path where the crds are located.")]
-    public string? CrdsPath { get; set; }
+    [Option("--crds-dir", Description = "The path where the CRD YAML files are located.")]
+    public string CrdsPath { get; set; } = "../crds";
 
-    [Option("--rbac-dir", Description = "The path where the rbac yamls are located.")]
-    public string? RbacPath { get; set; }
+    [Option("--rbac-dir", Description = "The path where the RBAC YAML files are located.")]
+    public string RbacPath { get; set; } = "../rbac";
 
-    [Option("--operator-dir", Description = "The path where the operator yamls are located.")]
-    public string? OperatorPath { get; set; }
+    [Option("--operator-dir", Description = "The path where the operator YAML files are located.")]
+    public string OperatorPath { get; set; } = "../operator";
 
-    [Option("--image-name", Description = "The name of the operator Docker image.")]
+    [Option("--image-name", Description = "The name of the operator's Docker image.")]
     public string ImageName { get; set; } = "public-docker-image-path";
 
-    [Option("--image-tag", Description = "The tag to use for the Docker image.")]
+    [Option("--image-tag", Description = "The tag for the Docker image.")]
     public string ImageTag { get; set; } = "latest";
 
     public async Task<int> OnExecuteAsync(CommandLineApplication app)
@@ -50,14 +50,14 @@ internal class InstallerGenerator : GeneratorBase
                     Resources = new List<string>
                     {
                         $"./namespace.{Format.ToString().ToLower()}",
-                        CrdsPath == null || OutputPath == null
-                            ? "../crds"
+                        OutputPath == null
+                            ? CrdsPath
                             : Path.GetRelativePath(OutputPath, CrdsPath).Replace('\\', '/'),
-                        RbacPath == null || OutputPath == null
-                            ? "../rbac"
+                        OutputPath == null
+                            ? RbacPath
                             : Path.GetRelativePath(OutputPath, RbacPath).Replace('\\', '/'),
-                        OperatorPath == null || OutputPath == null
-                            ? "../operator"
+                        OutputPath == null
+                            ? OperatorPath
                             : Path.GetRelativePath(OutputPath, OperatorPath).Replace('\\', '/'),
                     },
                     Images = new List<KustomizationImage>

--- a/src/KubeOps/Operator/Commands/Generators/InstallerGenerator.cs
+++ b/src/KubeOps/Operator/Commands/Generators/InstallerGenerator.cs
@@ -22,6 +22,12 @@ internal class InstallerGenerator : GeneratorBase
     [Option("--operator-dir", Description = "The path where the operator yamls are located.")]
     public string? OperatorPath { get; set; }
 
+    [Option("--image-name", Description = "The name of the operator Docker image.")]
+    public string ImageName { get; set; } = "public-docker-image-path";
+
+    [Option("--image-tag", Description = "The tag to use for the Docker image.")]
+    public string ImageTag { get; set; } = "latest";
+
     public async Task<int> OnExecuteAsync(CommandLineApplication app)
     {
         var fileWriter = new FileWriter(app.Out);
@@ -56,7 +62,7 @@ internal class InstallerGenerator : GeneratorBase
                     },
                     Images = new List<KustomizationImage>
                     {
-                        new() { Name = "operator", NewName = "public-docker-image-path", NewTag = "latest", },
+                        new() { Name = "operator", NewName = ImageName, NewTag = ImageTag, },
                     },
                 },
                 Format));

--- a/src/KubeOps/Operator/Commands/Generators/InstallerGenerator.cs
+++ b/src/KubeOps/Operator/Commands/Generators/InstallerGenerator.cs
@@ -6,8 +6,8 @@ using McMaster.Extensions.CommandLineUtils;
 
 namespace KubeOps.Operator.Commands.Generators;
 
-[Command("installer", Description = "Generates kustomization YAML that uses the output from the other generator commands to create the entire operator.")]
-internal class InstallerGenerator : GeneratorBase
+[Command("installer", Description = "Generates kustomization YAML for installing the entire operator.")]
+internal class InstallerGenerator : OutputBase
 {
     private readonly OperatorSettings _settings;
 

--- a/src/KubeOps/Operator/Commands/Generators/OperatorGenerator.cs
+++ b/src/KubeOps/Operator/Commands/Generators/OperatorGenerator.cs
@@ -8,7 +8,7 @@ using McMaster.Extensions.CommandLineUtils;
 namespace KubeOps.Operator.Commands.Generators;
 
 [Command("operator", "op", Description = "Generates the needed yamls to run the operator.")]
-internal class OperatorGenerator : GeneratorBase
+internal class OperatorGenerator : OutputBase
 {
     private readonly OperatorSettings _settings;
     private readonly bool _hasWebhooks;

--- a/src/KubeOps/Operator/Commands/Generators/OutputBase.cs
+++ b/src/KubeOps/Operator/Commands/Generators/OutputBase.cs
@@ -3,13 +3,15 @@ using McMaster.Extensions.CommandLineUtils;
 
 namespace KubeOps.Operator.Commands.Generators;
 
-internal abstract class GeneratorBase
+internal abstract class OutputBase
 {
-    [Option(CommandOptionType.SingleValue, Description = "Determines the output format for the generator.")]
+    [Option(
+        CommandOptionType.SingleValue,
+        Description = "Sets the output format for the generator.")]
     public SerializerOutputFormat Format { get; set; }
 
     [Option(
-        Description = @"The ""root"" path for the generator to put files in - if empty, prints to console.",
+        Description = @"The path the command will write the files to. If empty, prints output to console.",
         LongName = "out")]
     public string? OutputPath { get; set; }
 }

--- a/src/KubeOps/Operator/Commands/Generators/RbacGenerator.cs
+++ b/src/KubeOps/Operator/Commands/Generators/RbacGenerator.cs
@@ -8,7 +8,7 @@ using McMaster.Extensions.CommandLineUtils;
 namespace KubeOps.Operator.Commands.Generators;
 
 [Command("rbac", Description = "Generates the needed rbac roles for the operator.")]
-internal class RbacGenerator : GeneratorBase
+internal class RbacGenerator : OutputBase
 {
     private readonly IRbacBuilder _rbacBuilder;
 


### PR DESCRIPTION
Made a few changes to the 'generator installer' command to make it easier to script with. The command now has `--image-name` and `--image-tag` options so users can specify these values when the kustomization YAML is generated, instead of manually editing the file after the fact. Some of the other options for this command were not utilizing the McMaster CLI default value feature, so those values have been added in-line to make it clearer to users what the defaults are if they do not provide them. I also reworded some of the options to be more unambiguous about what is expected to be in those folders.

BREAKING CHANGE:
Additionally, the abstract `GeneratorBase` class has been renamed to `ConfigBase`, and the `Generator` class no longer inherits from `ConfigBase`. This was due to the fact that the `--out` and `--format` options were shown under the `generator` command, but they didn't actually do anything for _that_ command. Instead, it seems those options are only actually used by the sub-commands themselves (`docker`, `crds`, `rbac`, etc) when the YAML/JSON is generated. 

If that shouldn't be a breaking change, some dummy options can be created and hidden under the `generator` command to prevent CLI parsing errors. However, this will result in unexpected behavior for new users if they accidentally place their -o/-f options on the wrong command (resulting in the contents being output to the console).
