### PR TITLE
feat: use updated/faster JsonDiffPatch library 

### DIFF
--- a/src/KubeOps/KubeOps.csproj
+++ b/src/KubeOps/KubeOps.csproj
@@ -20,7 +20,6 @@
 
   <ItemGroup>
     <PackageReference Include="CompareNETObjects" Version="4.79.0" />
-    <PackageReference Include="JsonDiffPatch" Version="2.0.61" />
     <PackageReference Include="Localtunnel" Version="1.0.5" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.2" />
     <PackageReference Include="McMaster.Extensions.Hosting.CommandLine" Version="4.0.2" />
@@ -29,6 +28,7 @@
     <PackageReference Include="prometheus-net.AspNetCore.HealthChecks" Version="7.0.0" />
     <PackageReference Include="SimpleBase" Version="4.0.0" />
     <PackageReference Include="System.Reactive" Version="5.0.0" />
+    <PackageReference Include="SystemTextJson.JsonDiffPatch" Version="1.3.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">

--- a/src/KubeOps/Operator/Webhooks/KubernetesJsonDiffer.cs
+++ b/src/KubeOps/Operator/Webhooks/KubernetesJsonDiffer.cs
@@ -1,27 +1,27 @@
-﻿using JsonDiffPatch;
+﻿using System.Text.Json.JsonDiffPatch;
+using System.Text.Json.JsonDiffPatch.Diffs.Formatters;
+using System.Text.Json.Nodes;
 using k8s;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace KubeOps.Operator.Webhooks;
 
 internal static class KubernetesJsonDiffer
 {
-    private static readonly JsonDiffer JsonDiffer = new();
+    private static readonly JsonPatchDeltaFormatter Formatter = new();
 
-    public static PatchDocument DiffObjects(object? from, object? to)
+    public static JsonNode? DiffObjects(object? from, object? to)
     {
         var fromToken = GetJToken(from);
         var toToken = GetJToken(to);
 
-        return JsonDiffer.Diff(fromToken, toToken, false);
+        return fromToken.Diff(toToken, Formatter);
     }
 
-    private static JToken GetJToken(object? o)
+    private static JsonNode? GetJToken(object? o)
     {
         // Use the K8s Serializer to ensure we match their naming conventions
         // (and handle object conversions correctly).
         var json = KubernetesJson.Serialize(o);
-        return JToken.ReadFrom(new JsonTextReader(new StringReader(json)));
+        return JsonNode.Parse(json);
     }
 }

--- a/src/KubeOps/Operator/Webhooks/KubernetesJsonDiffer.cs
+++ b/src/KubeOps/Operator/Webhooks/KubernetesJsonDiffer.cs
@@ -9,12 +9,12 @@ internal static class KubernetesJsonDiffer
 {
     private static readonly JsonPatchDeltaFormatter Formatter = new();
 
-    public static JsonNode? DiffObjects(object? from, object? to)
+    public static JsonNode DiffObjects(object? from, object? to)
     {
         var fromToken = GetJToken(from);
         var toToken = GetJToken(to);
 
-        return fromToken.Diff(toToken, Formatter);
+        return fromToken.Diff(toToken, Formatter)!;
     }
 
     private static JsonNode? GetJToken(object? o)

--- a/tests/KubeOps.Test/Operator/Webhook/KubernetesJsonDiffer.Test.cs
+++ b/tests/KubeOps.Test/Operator/Webhook/KubernetesJsonDiffer.Test.cs
@@ -1,7 +1,6 @@
 ﻿using FluentAssertions;
 using k8s.Models;
 using KubeOps.Operator.Webhooks;
-using Newtonsoft.Json;
 using Xunit;
 
 namespace KubeOps.Test.Operator.Webhook;
@@ -17,7 +16,7 @@ public class KubernetesJsonDifferTest
         var result = KubernetesJsonDiffer.DiffObjects(left, right);
 
         // Should be all lowercase.
-        result.ToString(Formatting.None)
+        result.ToJsonString()
             .Should()
             .Be("[{\"op\":\"replace\",\"path\":\"/status/reason\",\"value\":\"bar\"}]");
     }

--- a/tests/KubeOps.Test/Operator/Webhook/KubernetesJsonDiffer.Test.cs
+++ b/tests/KubeOps.Test/Operator/Webhook/KubernetesJsonDiffer.Test.cs
@@ -20,4 +20,12 @@ public class KubernetesJsonDifferTest
             .Should()
             .Be("[{\"op\":\"replace\",\"path\":\"/status/reason\",\"value\":\"bar\"}]");
     }
+
+    [Fact]
+    public void When_diffing_null_objects_then_no_errors_should_be_thrown()
+    {
+        var result = KubernetesJsonDiffer.DiffObjects(null, null);
+
+        Assert.NotNull(result);
+    }
 }


### PR DESCRIPTION
The main motivation behind this change is to remove the deprecated transitive dependency `NetCoreApp 1.1` from `JsonDiffPatch`. This is causing validation issues in built images that are run through Aqua Trivy vulnerability scanner. 

A nice side-effect is that the diff should be much faster as it uses `System.Text.Json` instead of `Newtonsoft`.

Functionally, there should be no impact as both libraries adhere to `RFC 6902`.

@buehler 