### PR TITLE
[Feat] Merge Watch & Local events. Switch by uid & type grouping.

### DIFF
--- a/src/KubeOps/Operator/Caching/IResourceCache.cs
+++ b/src/KubeOps/Operator/Caching/IResourceCache.cs
@@ -10,6 +10,8 @@ internal interface IResourceCache<TEntity>
 
     TEntity Upsert(TEntity resource, out CacheComparisonResult result);
 
+    bool Exists(TEntity resource);
+
     void Fill(IEnumerable<TEntity> resources);
 
     void Remove(TEntity resource);

--- a/src/KubeOps/Operator/Caching/ResourceCache{TEntity}.cs
+++ b/src/KubeOps/Operator/Caching/ResourceCache{TEntity}.cs
@@ -74,6 +74,8 @@ internal class ResourceCache<TEntity> : IResourceCache<TEntity>
         _metrics.CachedItemsSummary.Observe(_cache.Count);
     }
 
+    public bool Exists(TEntity resource) => _cache.ContainsKey(resource.Metadata.Uid);
+
     private CacheComparisonResult CompareCache(TEntity resource)
     {
         if (!Exists(resource))
@@ -100,8 +102,6 @@ internal class ResourceCache<TEntity> : IResourceCache<TEntity>
 
         return CacheComparisonResult.Other;
     }
-
-    private bool Exists(TEntity resource) => _cache.ContainsKey(resource.Metadata.Uid);
 
     private void Remove(string resourceUid)
     {

--- a/src/KubeOps/Operator/Controller/EventQueue.cs
+++ b/src/KubeOps/Operator/Controller/EventQueue.cs
@@ -49,8 +49,10 @@ internal class EventQueue<TEntity> : IEventQueue<TEntity>
             .GroupBy(e => e.Resource.Uid())
             .Select(
                 group => group
-                    .Select(ProcessDelay)
-                    .Switch())
+                    .GroupBy(e => e.Type)
+                    .Select(typedGroup => typedGroup
+                        .Select(ProcessDelay).Switch())
+                    .Merge())
             .Merge()
             .Select(UpdateResourceData)
             .Merge()


### PR DESCRIPTION
Watcher and Local events are now merged to produce a sequence containing all captured events instead of just the sequence that was last produced. Events will still be switch but only at group level, grouping by resource Uid and sub-grouping by event type, therefore Keeping alway last event for each type of each resources, preventing events accumulation.

Fixes #585 #579