### PR TITLE
Fixed ToExpression(this IEnumerable<LabelSelector> selectors) extension method

### DIFF
--- a/src/KubeOps.KubernetesClient/LabelSelectors/Extensions.cs
+++ b/src/KubeOps.KubernetesClient/LabelSelectors/Extensions.cs
@@ -8,5 +8,5 @@ public static class Extensions
     /// <param name="selectors">The list of selectors.</param>
     /// <returns>A comma-joined string with all selectors converted to their expressions.</returns>
     public static string ToExpression(this IEnumerable<LabelSelector> selectors) =>
-        string.Join(",", selectors);
+        string.Join(",", selectors.Select(x => (string)x));
 }

--- a/test/KubeOps.KubernetesClient.Test/LabelSelector.Test.cs
+++ b/test/KubeOps.KubernetesClient.Test/LabelSelector.Test.cs
@@ -1,0 +1,19 @@
+﻿using KubeOps.KubernetesClient.LabelSelectors;
+
+namespace KubeOps.KubernetesClient.Test;
+
+public class LabelSelectorTest : IntegrationTestBase
+{
+    [Fact]
+    public void Sould_Return_Correct_Expression()
+    {
+        var labelSelectors = new LabelSelector[] {
+            new EqualsSelector("app", Enumerable.Range(0,3).Select(x=>$"app-{x}").ToArray()),
+            new NotEqualsSelector("srv", Enumerable.Range(0,2).Select(x=>$"service-{x}").ToArray())
+        };
+
+        string expected = "app in (app-0,app-1,app-2),srv notin (service-0,service-1)";
+        var actual = labelSelectors.ToExpression();
+        Assert.Equal(expected, actual);
+    }
+}


### PR DESCRIPTION
Current inplementation of ```ToExpression(this IEnumerable<LabelSelector> selectors)``` extension method returns wrong result

```
EqualsSelector { Label = app, Values = System.String[] },NotEqualsSelector { Label = srv, Values = System.String[] }
```

it just serialize record LabelSelector to ```EqualsSelector { Label = app, Values = System.String[] }``` or to ```NotEqualsSelector { Label = srv, Values = System.String[] }``` instead of calling implicit to string convertor.


The proposed pull request corrects this unpleasant behavior. Tests are attached.