### PR TITLE
fix: make JsonDiffer thread safe

### DIFF
--- a/src/KubeOps.Operator.Web/Webhooks/Admission/Mutation/JsonDiffer.cs
+++ b/src/KubeOps.Operator.Web/Webhooks/Admission/Mutation/JsonDiffer.cs
@@ -9,12 +9,12 @@ namespace KubeOps.Operator.Web.Webhooks.Admission.Mutation;
 
 internal static class JsonDiffer
 {
-    private static readonly JsonPatchDeltaFormatter Formatter = new();
-
     public static string Base64Diff(this JsonNode from, object? to)
     {
+        JsonPatchDeltaFormatter formatter = new();
+
         var toToken = GetNode(to);
-        var patch = from.Diff(toToken, Formatter)!;
+        var patch = from.Diff(toToken, formatter)!;
 
         return Convert.ToBase64String(Encoding.UTF8.GetBytes(patch.ToString()));
     }

--- a/src/KubeOps.Operator.Web/Webhooks/Admission/Mutation/JsonDiffer.cs
+++ b/src/KubeOps.Operator.Web/Webhooks/Admission/Mutation/JsonDiffer.cs
@@ -11,7 +11,7 @@ internal static class JsonDiffer
 {
     public static string Base64Diff(this JsonNode from, object? to)
     {
-        JsonPatchDeltaFormatter formatter = new();
+        var formatter = new JsonPatchDeltaFormatter();
 
         var toToken = GetNode(to);
         var patch = from.Diff(toToken, formatter)!;


### PR DESCRIPTION
Concurrent execution of JsonDiffer() on multiple threads causes ArgumentOutOfRangeException during Dispose().
Create new instance of JsonPatchDeltaFormatter for every call.
Please refer to this issue: https://github.com/buehler/dotnet-operator-sdk/issues/682