### PR TITLE
fix: Transpiler inconsistencies for CRDs

### DIFF
--- a/examples/Operator/Entities/V1TestEntity.cs
+++ b/examples/Operator/Entities/V1TestEntity.cs
@@ -14,5 +14,6 @@ public partial class V1TestEntity : CustomKubernetesEntity<V1TestEntity.EntitySp
         public string Username { get; set; } = string.Empty;
 
         public string Email { get; set; } = string.Empty;
+        public V1JobSpec? Test { get; set; }
     }
 }

--- a/examples/Operator/Entities/V1TestEntity.cs
+++ b/examples/Operator/Entities/V1TestEntity.cs
@@ -14,6 +14,5 @@ public partial class V1TestEntity : CustomKubernetesEntity<V1TestEntity.EntitySp
         public string Username { get; set; } = string.Empty;
 
         public string Email { get; set; } = string.Empty;
-        public V1JobSpec? Test { get; set; }
     }
 }

--- a/src/KubeOps.Transpiler/Crds.cs
+++ b/src/KubeOps.Transpiler/Crds.cs
@@ -306,7 +306,7 @@ public static class Crds
                 .First(i => i.IsGenericType
                          && i.GetGenericTypeDefinition().FullName == typeof(IDictionary<,>).FullName);
 
-            var addlProps = context.Map(dictionaryImpl.GenericTypeArguments[1]); 
+            var addlProps = context.Map(dictionaryImpl.GenericTypeArguments[1]);
             return new V1JSONSchemaProps
             {
                 Type = Object,

--- a/src/KubeOps.Transpiler/Crds.cs
+++ b/src/KubeOps.Transpiler/Crds.cs
@@ -302,10 +302,15 @@ public static class Crds
 
         if (interfaceNames.Contains(typeof(IDictionary<,>).FullName))
         {
+            var dictionaryImpl = interfaces
+                .First(i => i.IsGenericType
+                         && i.GetGenericTypeDefinition().FullName == typeof(IDictionary<,>).FullName);
+
+            var addlProps = context.Map(dictionaryImpl.GenericTypeArguments[1]); 
             return new V1JSONSchemaProps
             {
                 Type = Object,
-                AdditionalProperties = new object() { },
+                AdditionalProperties = addlProps,
                 Nullable = false,
             };
         }
@@ -315,7 +320,6 @@ public static class Crds
             return new V1JSONSchemaProps
             {
                 Type = Object,
-                AdditionalProperties = new object() { },
                 XKubernetesPreserveUnknownFields = true,
                 Nullable = false,
             };
@@ -400,8 +404,8 @@ public static class Crds
         Type listType = enumerableType.GenericTypeArguments[0];
         if (listType.IsGenericType && listType.GetGenericTypeDefinition().FullName == typeof(KeyValuePair<,>).FullName)
         {
-            // XKubernetesPreserveUnknownFields = true ??
-            return new V1JSONSchemaProps { Type = Object, AdditionalProperties = new object() { }, Nullable = false };
+            var addlProps = context.Map(listType.GenericTypeArguments[1]);
+            return new V1JSONSchemaProps { Type = Object, AdditionalProperties = addlProps, Nullable = false };
         }
 
         var items = context.Map(listType);

--- a/test/KubeOps.Transpiler.Test/Crds.Mlc.Test.cs
+++ b/test/KubeOps.Transpiler.Test/Crds.Mlc.Test.cs
@@ -73,6 +73,16 @@ public class CrdsMlcTest(MlcProvider provider) : TranspilerTestBase(provider)
         prop.Nullable.Should().Be(isNullable);
     }
 
+    [Theory]
+    [InlineData(typeof(DictionaryEntity), "string", false)]
+    [InlineData(typeof(EnumerableKeyPairsEntity), "string", false)]
+    public void Should_Set_Correct_Dictionary_Additional_Properties_Type(Type type, string expectedType, bool isNullable) {
+        var crd = _mlc.Transpile(type);
+        var prop = crd.Spec.Versions.First().Schema.OpenAPIV3Schema.Properties["property"].AdditionalProperties as V1JSONSchemaProps;
+        prop!.Type.Should().Be(expectedType);
+        prop.Nullable.Should().Be(isNullable);
+    }
+
     [Fact]
     public void Should_Ignore_Entity()
     {

--- a/test/KubeOps.Transpiler.Test/Crds.Mlc.Test.cs
+++ b/test/KubeOps.Transpiler.Test/Crds.Mlc.Test.cs
@@ -22,12 +22,16 @@ public class CrdsMlcTest(MlcProvider provider) : TranspilerTestBase(provider)
     [InlineData(typeof(NullableLongTestEntity), "integer", "int64", true)]
     [InlineData(typeof(FloatTestEntity), "number", "float", false)]
     [InlineData(typeof(NullableFloatTestEntity), "number", "float", true)]
+    [InlineData(typeof(DecimalTestEntity), "number", "decimal", false)]
+    [InlineData(typeof(NullableDecimalTestEntity), "number", "decimal", true)]
     [InlineData(typeof(DoubleTestEntity), "number", "double", false)]
     [InlineData(typeof(NullableDoubleTestEntity), "number", "double", true)]
     [InlineData(typeof(BoolTestEntity), "boolean", null, false)]
     [InlineData(typeof(NullableBoolTestEntity), "boolean", null, true)]
     [InlineData(typeof(DateTimeTestEntity), "string", "date-time", false)]
     [InlineData(typeof(NullableDateTimeTestEntity), "string", "date-time", true)]
+    [InlineData(typeof(DateTimeOffsetTestEntity), "string", "date-time", false)]
+    [InlineData(typeof(NullableDateTimeOffsetTestEntity), "string", "date-time", true)]
     [InlineData(typeof(V1ObjectMetaTestEntity), "object", null, false)]
     [InlineData(typeof(StringArrayEntity), "array", null, false)]
     [InlineData(typeof(NullableStringArrayEntity), "array", null, true)]
@@ -509,6 +513,18 @@ public class CrdsMlcTest(MlcProvider provider) : TranspilerTestBase(provider)
     }
 
     [KubernetesEntity(Group = "testing.dev", ApiVersion = "v1", Kind = "TestEntity")]
+    private class DecimalTestEntity : CustomKubernetesEntity
+    {
+        public decimal Property { get; set; }
+    }
+
+    [KubernetesEntity(Group = "testing.dev", ApiVersion = "v1", Kind = "TestEntity")]
+    private class NullableDecimalTestEntity : CustomKubernetesEntity
+    {
+        public decimal? Property { get; set; }
+    }
+
+    [KubernetesEntity(Group = "testing.dev", ApiVersion = "v1", Kind = "TestEntity")]
     private class DoubleTestEntity : CustomKubernetesEntity
     {
         public double Property { get; set; }
@@ -542,6 +558,18 @@ public class CrdsMlcTest(MlcProvider provider) : TranspilerTestBase(provider)
     private class NullableDateTimeTestEntity : CustomKubernetesEntity
     {
         public DateTime? Property { get; set; }
+    }
+
+    [KubernetesEntity(Group = "testing.dev", ApiVersion = "v1", Kind = "TestEntity")]
+    private class DateTimeOffsetTestEntity : CustomKubernetesEntity
+    {
+        public DateTimeOffset Property { get; set; }
+    }
+
+    [KubernetesEntity(Group = "testing.dev", ApiVersion = "v1", Kind = "TestEntity")]
+    private class NullableDateTimeOffsetTestEntity : CustomKubernetesEntity
+    {
+        public DateTimeOffset? Property { get; set; }
     }
 
     [KubernetesEntity(Group = "testing.dev", ApiVersion = "v1", Kind = "TestEntity")]


### PR DESCRIPTION
Howdy

Some context for this reasonably large refactor:
- There appears to be mostly consistent issues with the CRD transpiler with 8.0.0-pre.40 as communicated #687 
- This issue was not limited to int/int? alone after further investigation, but instead a whole slew of types (DateTime,bool,bool?,etc)
- long story short, type equality checks were the culprit (and I have no idea why). My best guess is that something is off with my machine.
- While switching out conditions, I noticed opportunities to simplify

I packaged up the code and published it to a local nuget server before installing it in a project. I was able to build the CRD for this entity without any issues with these changes (functionally the kubebuilder book CronJob example):

```csharp
[k8s.Models.KubernetesEntity(Group = Constants.Operator.Group, ApiVersion = "v1", Kind = "CronJob")]
public partial class V1CronJob : CustomKubernetesEntity<V1CronJob.EntitySpec, V1CronJob.EntityStatus> {
    public class EntitySpec {
        [Required]
        public string Schedule { get; set; } = string.Empty;
        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
        public DateTimeOffset? StartingDeadlineSeconds { get; set; }
        [AllowedValues("Allow","Forbid","Replace")]
        public string? ConcurrencyPolicy { get; set; }
        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
        public bool? Suspend { get; set; }
        [Required]
        [EmbeddedResource]
        public k8s.Models.V1JobTemplateSpec JobTemplate { get; set; } = new();
        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
        public int? SuccessfulJobsHistoryLimit { get; set; } = 3;
        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
        public int? FailedJobsHistoryLimit { get; set; } = 1;
    }

    public class EntityStatus {
        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
        public string? LastScheduleTime { get; set; } = default;
        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
        public List<k8s.Models.V1ObjectReference> Active { get; set; } = new();
    }

    public static class ConcurrencyPolicy {
        public const string Allow = "Allow";
        public const string Forbid = "Forbid";
        public const string Replace = "Replace";
    }
}
```

this produced the following yaml:

```yaml
openAPIV3Schema:
  properties:
    status:
      nullable: false
      properties:
        lastScheduleTime:
          nullable: true
          type: string
        active:
          items:
            properties:
              apiVersion:
                nullable: false
                type: string
              fieldPath:
                nullable: false
                type: string
              kind:
                nullable: false
                type: string
              name:
                nullable: false
                type: string
              namespace:
                nullable: false
                type: string
              resourceVersion:
                nullable: false
                type: string
              uid:
                nullable: false
                type: string
            type: object
          nullable: false
          type: array
      type: object
    spec:
      nullable: false
      properties:
        schedule:
          nullable: false
          type: string
        startingDeadlineSeconds:
          format: date-time
          nullable: true
          type: string
        concurrencyPolicy:
          nullable: true
          type: string
        suspend:
          nullable: true
          type: boolean
        jobTemplate:
          nullable: false
          type: object
          x-kubernetes-embedded-resource: true
          x-kubernetes-preserve-unknown-fields: true
        successfulJobsHistoryLimit:
          format: int32
          nullable: true
          type: integer
        failedJobsHistoryLimit:
          format: int32
          nullable: true
          type: integer
      required:
      - schedule
      - jobTemplate
      type: object
  type: object
```

I also added decimal & DateTimeOffset support due to presence here:
- https://microsoft.github.io/typespec/getting-started/typespec-for-openapi-dev#type-and-format

**DISCLAIMER**: I have no idea what the CRD yaml output _should_ look like. My main goal was to honor the current test suite.

Let me know if there is anything I can do for this PR, but the CRD gen is largely not usable at the moment for me, and I'm still very much confused why that is the case and why there appears to be no mention of the same issue from others.

Thanks