### PR TITLE
fix: don't access disposed resources

### DIFF
--- a/src/KubeOps.KubernetesClient/KubernetesClient.cs
+++ b/src/KubeOps.KubernetesClient/KubernetesClient.cs
@@ -428,12 +428,10 @@ public class KubernetesClient : IKubernetesClient
 
     protected virtual void Dispose(bool disposing)
     {
-        if (!disposing)
+        if (!disposing || _disposed)
         {
             return;
         }
-
-        ThrowIfDisposed();
 
         // The property is intentionally set before the underlying _client is disposed.
         // This ensures that even if the disposal of the client is not finished yet, that all calls to the client

--- a/test/KubeOps.Operator.Test/HostedServices/LeaderResourceWatcher.Integration.Test.cs
+++ b/test/KubeOps.Operator.Test/HostedServices/LeaderResourceWatcher.Integration.Test.cs
@@ -1,0 +1,25 @@
+using KubeOps.Abstractions.Controller;
+using KubeOps.Operator.Test.TestEntities;
+
+using Microsoft.Extensions.Hosting;
+
+namespace KubeOps.Operator.Test.HostedServices;
+
+public class LeaderAwareHostedServiceDisposeIntegrationTest : HostedServiceDisposeIntegrationTest
+{
+    protected override void ConfigureHost(HostApplicationBuilder builder)
+    {
+        builder.Services
+            .AddKubernetesOperator(op => op.EnableLeaderElection = true)
+            .AddController<TestController, V1OperatorIntegrationTestEntity>();
+    }
+
+    private class TestController : IEntityController<V1OperatorIntegrationTestEntity>
+    {
+        public Task ReconcileAsync(V1OperatorIntegrationTestEntity entity, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+
+        public Task DeletedAsync(V1OperatorIntegrationTestEntity entity, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+    }
+}

--- a/test/KubeOps.Operator.Test/HostedServices/ResourceWatcher.Integration.Test.cs
+++ b/test/KubeOps.Operator.Test/HostedServices/ResourceWatcher.Integration.Test.cs
@@ -1,0 +1,54 @@
+using KubeOps.Abstractions.Controller;
+using KubeOps.Operator.Test.TestEntities;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace KubeOps.Operator.Test.HostedServices;
+
+public class HostedServiceDisposeIntegrationTest : IntegrationTestBase
+{
+    [Fact]
+    public async Task Should_Allow_DisposeAsync_Before_StopAsync()
+    {
+        var hostedServices = Services.GetServices<IHostedService>()
+            .Where(service => service.GetType().Namespace!.StartsWith("KubeOps"));
+
+        // We need to test the inverse order, because the Host is usually disposing the resources in advance of
+        // stopping them.
+        foreach (IHostedService service in hostedServices)
+        {
+            await Assert.IsAssignableFrom<IAsyncDisposable>(service).DisposeAsync();
+            await service.StopAsync(CancellationToken.None);
+        }
+    }
+
+    [Fact]
+    public async Task Should_Allow_StopAsync_Before_DisposeAsync()
+    {
+        var hostedServices = Services.GetServices<IHostedService>()
+            .Where(service => service.GetType().Namespace!.StartsWith("KubeOps"));
+
+        foreach (IHostedService service in hostedServices)
+        {
+            await service.StopAsync(CancellationToken.None);
+            await Assert.IsAssignableFrom<IAsyncDisposable>(service).DisposeAsync();
+        }
+    }
+
+    protected override void ConfigureHost(HostApplicationBuilder builder)
+    {
+        builder.Services
+            .AddKubernetesOperator()
+            .AddController<TestController, V1OperatorIntegrationTestEntity>();
+    }
+
+    private class TestController : IEntityController<V1OperatorIntegrationTestEntity>
+    {
+        public Task ReconcileAsync(V1OperatorIntegrationTestEntity entity, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+
+        public Task DeletedAsync(V1OperatorIntegrationTestEntity entity, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
This PR is ensuring that the host does not stop with an exception. Those exceptions were occuring because the `CancellationTokenSource` inside the hosted services was already disposed when `StopAsync` got called.
The reason for this is that the host invokes `DisposeAsync` **before** `StopAsync`.
