### PR TITLE
Adding guid to generated filename

### DIFF
--- a/src/KubeOps.Generator/Generators/ControllerRegistrationGenerator.cs
+++ b/src/KubeOps.Generator/Generators/ControllerRegistrationGenerator.cs
@@ -79,7 +79,7 @@ internal class ControllerRegistrationGenerator : ISourceGenerator
             .NormalizeWhitespace();
 
         context.AddSource(
-            "ControllerRegistrations.g.cs",
+            $"ControllerRegistrations.{Guid.NewGuid()}.g.cs",
             SourceText.From(declaration.ToString(), Encoding.UTF8, SourceHashAlgorithm.Sha256));
     }
 }

--- a/src/KubeOps.Generator/Generators/EntityDefinitionGenerator.cs
+++ b/src/KubeOps.Generator/Generators/EntityDefinitionGenerator.cs
@@ -82,7 +82,7 @@ internal class EntityDefinitionGenerator : ISourceGenerator
             .NormalizeWhitespace();
 
         context.AddSource(
-            "EntityDefinitions.g.cs",
+            $"EntityDefinitions.{Guid.NewGuid()}.g.cs",
             SourceText.From(declaration.ToString(), Encoding.UTF8, SourceHashAlgorithm.Sha256));
     }
 }

--- a/src/KubeOps.Generator/Generators/FinalizerRegistrationGenerator.cs
+++ b/src/KubeOps.Generator/Generators/FinalizerRegistrationGenerator.cs
@@ -102,7 +102,7 @@ internal class FinalizerRegistrationGenerator : ISourceGenerator
             .NormalizeWhitespace();
 
         context.AddSource(
-            "FinalizerRegistrations.g.cs",
+            $"FinalizerRegistrations.{Guid.NewGuid()}.g.cs",
             SourceText.From(declaration.ToString(), Encoding.UTF8, SourceHashAlgorithm.Sha256));
     }
 

--- a/src/KubeOps.Generator/Generators/OperatorBuilderGenerator.cs
+++ b/src/KubeOps.Generator/Generators/OperatorBuilderGenerator.cs
@@ -54,7 +54,7 @@ internal class OperatorBuilderGenerator : ISourceGenerator
             .NormalizeWhitespace();
 
         context.AddSource(
-            "OperatorBuilder.g.cs",
+            $"OperatorBuilder.{Guid.NewGuid()}.g.cs",
             SourceText.From(declaration.ToString(), Encoding.UTF8, SourceHashAlgorithm.Sha256));
     }
 }

--- a/test/KubeOps.Generator.Test/ControllerRegistrationGenerator.Test.cs
+++ b/test/KubeOps.Generator.Test/ControllerRegistrationGenerator.Test.cs
@@ -50,7 +50,7 @@ public class ControllerRegistrationGeneratorTest
         driver.RunGeneratorsAndUpdateCompilation(inputCompilation, out var output, out var diag);
 
         var result = output.SyntaxTrees
-            .First(s => s.FilePath.Contains("ControllerRegistrations.g.cs"))
+            .First(s => s.FilePath.Contains("ControllerRegistrations."))
             .ToString().ReplaceLineEndings();
         result.Should().Be(expectedResult);
     }

--- a/test/KubeOps.Generator.Test/EntityDefinitionGenerator.Test.cs
+++ b/test/KubeOps.Generator.Test/EntityDefinitionGenerator.Test.cs
@@ -60,7 +60,7 @@ public class EntityDefinitionGeneratorTest
         driver.RunGeneratorsAndUpdateCompilation(inputCompilation, out var output, out var diag);
 
         var result = output.SyntaxTrees
-            .First(s => s.FilePath.Contains("EntityDefinitions.g.cs"))
+            .First(s => s.FilePath.Contains("EntityDefinitions."))
             .ToString().ReplaceLineEndings();
         result.Should().Be(expectedResult);
     }

--- a/test/KubeOps.Generator.Test/EntityInitializerGenerator.Test.cs
+++ b/test/KubeOps.Generator.Test/EntityInitializerGenerator.Test.cs
@@ -22,7 +22,7 @@ public class EntityInitializerGeneratorTest
         driver.RunGeneratorsAndUpdateCompilation(inputCompilation, out var output, out var diag);
 
         var result = output.SyntaxTrees
-            .First(s => s.FilePath.Contains("EntityInitializer.g.cs"))
+            .First(s => s.FilePath.Contains("EntityInitializer."))
             .ToString().ReplaceLineEndings();
         result.Should().Be(expectedResult);
     }
@@ -66,7 +66,7 @@ public class EntityInitializerGeneratorTest
         output.SyntaxTrees.Any(s => s.FilePath.Contains("V1TestEntity")).Should().BeFalse();
         output.SyntaxTrees.Any(s => s.FilePath.Contains("V2TestEntity")).Should().BeFalse();
         var result = output.SyntaxTrees
-            .First(s => s.FilePath.Contains("EntityInitializer.g.cs"))
+            .First(s => s.FilePath.Contains("EntityInitializer."))
             .ToString().ReplaceLineEndings();
         result.Should().Be(expectedResult);
     }

--- a/test/KubeOps.Generator.Test/FinalizerRegistrationGenerator.Test.cs
+++ b/test/KubeOps.Generator.Test/FinalizerRegistrationGenerator.Test.cs
@@ -79,7 +79,7 @@ public class FinalizerRegistrationGeneratorTest
         driver.RunGeneratorsAndUpdateCompilation(inputCompilation, out var output, out var diag);
 
         var result = output.SyntaxTrees
-            .First(s => s.FilePath.Contains("FinalizerRegistrations.g.cs"))
+            .First(s => s.FilePath.Contains("FinalizerRegistrations."))
             .ToString().ReplaceLineEndings();
         result.Should().Be(expectedResult);
     }

--- a/test/KubeOps.Generator.Test/OperatorBuilderGenerator.Test.cs
+++ b/test/KubeOps.Generator.Test/OperatorBuilderGenerator.Test.cs
@@ -31,7 +31,7 @@ public class OperatorBuilderGeneratorTest
         driver.RunGeneratorsAndUpdateCompilation(inputCompilation, out var output, out var diag);
 
         var result = output.SyntaxTrees
-            .First(s => s.FilePath.Contains("OperatorBuilder.g.cs"))
+            .First(s => s.FilePath.Contains("OperatorBuilder."))
             .ToString().ReplaceLineEndings();
         result.Should().Be(expectedResult);
     }


### PR DESCRIPTION
This will allow the different components to be separated into different projects. This can be helpful in the case where you have the entities in a different project to be published in a nuget package