### PR TITLE
fixes(#739): No retry is performed when the ResourceWatcher fail to watch a resource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ coverage.info
 
 # Docs
 _site
+
+.idea/
+global.json

--- a/src/KubeOps.KubernetesClient/ExceptionExtensions.cs
+++ b/src/KubeOps.KubernetesClient/ExceptionExtensions.cs
@@ -1,0 +1,28 @@
+using System.Text.RegularExpressions;
+
+namespace KubeOps.KubernetesClient;
+
+/// <summary>
+/// Method extensions for the <see cref="Exception"/> class.
+/// </summary>
+public static class ExceptionExtensions
+{
+    /// <summary>
+    /// Walk through all collected Exceptions (base exception and all inner exceptions) LINQ style.
+    /// </summary>
+    public static IEnumerable<Exception> All(this Exception self)
+    {
+        if (self == null)
+        {
+            throw new ArgumentNullException(nameof(self));
+        }
+
+        var cause = self;
+        do
+        {
+            yield return cause;
+            cause = ReferenceEquals(cause, cause.InnerException) ? null : cause.InnerException;
+        }
+        while (cause != null && !ReferenceEquals(cause, self));
+    }
+}

--- a/src/KubeOps.KubernetesClient/IKubernetesClient.cs
+++ b/src/KubeOps.KubernetesClient/IKubernetesClient.cs
@@ -413,6 +413,7 @@ public interface IKubernetesClient : IDisposable
     /// When specified with a watch call, shows changes that occur after that particular version of a resource.
     /// Defaults to changes from the beginning of history.
     /// </param>
+    /// <param name="allowWatchBookmarks">allowWatchBookmarks requests watch events with type &quot;BOOKMARK&quot; for proper ResourceVersion handling.</param>
     /// <param name="cancellationToken">Cancellation-Token.</param>
     /// <param name="labelSelectors">A list of label-selectors to apply to the search.</param>
     /// <returns>A entity watcher for the given entity.</returns>
@@ -423,6 +424,7 @@ public interface IKubernetesClient : IDisposable
         string? @namespace = null,
         TimeSpan? timeout = null,
         string? resourceVersion = null,
+        bool? allowWatchBookmarks = null,
         CancellationToken cancellationToken = default,
         params LabelSelector[] labelSelectors)
         where TEntity : IKubernetesObject<V1ObjectMeta>
@@ -434,6 +436,7 @@ public interface IKubernetesClient : IDisposable
             timeout,
             resourceVersion,
             labelSelectors.ToExpression(),
+            allowWatchBookmarks,
             cancellationToken);
 
     /// <summary>
@@ -455,6 +458,7 @@ public interface IKubernetesClient : IDisposable
     /// Defaults to changes from the beginning of history.
     /// </param>
     /// <param name="labelSelector">A string, representing an optional label selector for filtering watched objects.</param>
+    /// <param name="allowWatchBookmarks">allowWatchBookmarks requests watch events with type &quot;BOOKMARK&quot; for proper ResourceVersion handling.</param>
     /// <param name="cancellationToken">Cancellation-Token.</param>
     /// <returns>A entity watcher for the given entity.</returns>
     Watcher<TEntity> Watch<TEntity>(
@@ -465,6 +469,7 @@ public interface IKubernetesClient : IDisposable
         TimeSpan? timeout = null,
         string? resourceVersion = null,
         string? labelSelector = null,
+        bool? allowWatchBookmarks = null,
         CancellationToken cancellationToken = default)
         where TEntity : IKubernetesObject<V1ObjectMeta>;
 
@@ -480,6 +485,7 @@ public interface IKubernetesClient : IDisposable
     /// Defaults to changes from the beginning of history.
     /// </param>
     /// <param name="labelSelector">A string, representing an optional label selector for filtering watched objects.</param>
+    /// <param name="allowWatchBookmarks">allowWatchBookmarks requests watch events with type &quot;BOOKMARK&quot; for proper ResourceVersion handling.</param>
     /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
     /// <typeparam name="TEntity">The type of the Kubernetes entity.</typeparam>
     /// <returns>An asynchronous enumerable that finishes once <paramref name="cancellationToken"/> is cancelled.</returns>
@@ -487,6 +493,7 @@ public interface IKubernetesClient : IDisposable
         string? @namespace = null,
         string? resourceVersion = null,
         string? labelSelector = null,
+        bool? allowWatchBookmarks = null,
         CancellationToken cancellationToken = default)
         where TEntity : IKubernetesObject<V1ObjectMeta>;
 
@@ -509,6 +516,7 @@ public interface IKubernetesClient : IDisposable
     /// Defaults to changes from the beginning of history.
     /// </param>
     /// <param name="labelSelector">A string, representing an optional label selector for filtering watched objects.</param>
+    /// <param name="allowWatchBookmarks">allowWatchBookmarks requests watch events with type &quot;BOOKMARK&quot; for proper ResourceVersion handling.</param>
     /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
     /// <typeparam name="TEntity">The type of the Kubernetes entity.</typeparam>
     /// <returns>A task that completes when the watcher ends.</returns>
@@ -518,6 +526,7 @@ public interface IKubernetesClient : IDisposable
         string? @namespace = null,
         string? resourceVersion = null,
         string? labelSelector = null,
+        bool? allowWatchBookmarks = null,
         CancellationToken cancellationToken = default)
         where TEntity : IKubernetesObject<V1ObjectMeta>;
 }

--- a/src/KubeOps.KubernetesClient/IKubernetesClient.cs
+++ b/src/KubeOps.KubernetesClient/IKubernetesClient.cs
@@ -496,6 +496,10 @@ public interface IKubernetesClient : IDisposable
     /// and the watch is automatically recreated in such cases.
     /// </summary>
     /// <param name="eventTask">(async) Task Action that is executed when an event occurs.</param>
+    /// <param name="onTransientError">
+    /// Action that handles exceptions leading to automatically re-creating the watch.
+    /// Throwing any exception inside this handler will immediately break out of the current watch.
+    /// </param>
     /// <param name="namespace">
     /// The namespace to watch for entities (if needed).
     /// If the namespace is omitted, all entities on the cluster are watched.
@@ -510,6 +514,7 @@ public interface IKubernetesClient : IDisposable
     /// <returns>A task that completes when the watcher ends.</returns>
     public Task WatchSafeAsync<TEntity>(
         Func<WatchEventType, TEntity?, CancellationToken, Task> eventTask,
+        Action<Exception>? onTransientError = null,
         string? @namespace = null,
         string? resourceVersion = null,
         string? labelSelector = null,

--- a/src/KubeOps.Operator/Watcher/BackoffPolicy.cs
+++ b/src/KubeOps.Operator/Watcher/BackoffPolicy.cs
@@ -1,0 +1,45 @@
+namespace KubeOps.Operator.Watcher;
+
+/// <summary>
+/// Simple exponential backoff logic.
+/// </summary>
+public class BackoffPolicy(CancellationToken stoppingToken, Func<int, TimeSpan> policy)
+{
+    private int _retries = 0;
+
+    /// <summary>
+    /// Default exponential backoff algorithm
+    /// </summary>
+    public static Func<int, TimeSpan> ExponentialWithJitter(int maxExp = 5, int jitterMillis = 1000)
+        => retries => TimeSpan.FromSeconds(Math.Pow(2, Math.Clamp(retries, 0, maxExp)))
+            .Add(TimeSpan.FromMilliseconds(new Random().Next(0, jitterMillis)));
+
+    /// <summary>
+    /// Clear all counters.
+    /// </summary>
+    public void Clear()
+    {
+        _retries = 0;
+    }
+
+    /// <summary>
+    /// Adds a delay.
+    /// </summary>
+    /// <param name="ex"><see cref="Exception"/>.</param>
+    /// <returns><see cref="Task"/>.</returns>
+    public async Task WaitOnException(Exception ex)
+    {
+        try
+        {
+            _retries++;
+            await Task.Delay(WaitTime(), stoppingToken);
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            // Do nothing
+        }
+    }
+
+    private TimeSpan WaitTime()
+        => policy(_retries);
+}

--- a/src/KubeOps.Operator/Watcher/ResourceWatcher{TEntity}.cs
+++ b/src/KubeOps.Operator/Watcher/ResourceWatcher{TEntity}.cs
@@ -141,9 +141,10 @@ internal class ResourceWatcher<TEntity>(
                 onError.Clear();
                 await client.WatchSafeAsync<TEntity>(
                     eventTask: OnEventAsync,
-                    onTransientError: ex => logger.LogInformation("watch re-created due to transient error - resource: {Resource}, cause: {Cause}", typeof(TEntity), ex.Message),
+                    onTransientError: ex => logger.LogWarning("watch re-created due to transient error - resource: {Resource}, cause: ({ExceptionType}) {Cause}", typeof(TEntity), ex.GetType(), ex.Message),
                     @namespace: settings.Namespace,
                     resourceVersion: resourceVersion,
+                    allowWatchBookmarks: true, // needed for proper ResourceVersion handling in order to keep the watch alive
                     cancellationToken: stoppingToken);
             }
             catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)

--- a/src/KubeOps.Operator/Watcher/ResourceWatcher{TEntity}.cs
+++ b/src/KubeOps.Operator/Watcher/ResourceWatcher{TEntity}.cs
@@ -141,6 +141,7 @@ internal class ResourceWatcher<TEntity>(
                 onError.Clear();
                 await client.WatchSafeAsync<TEntity>(
                     eventTask: OnEventAsync,
+                    onTransientError: ex => logger.LogInformation("watch re-created due to transient error - resource: {Resource}, cause: {Cause}", typeof(TEntity), ex.Message),
                     @namespace: settings.Namespace,
                     resourceVersion: resourceVersion,
                     cancellationToken: stoppingToken);

--- a/test/KubeOps.KubernetesClient.Test/KubernetesClient.Test.cs
+++ b/test/KubeOps.KubernetesClient.Test/KubernetesClient.Test.cs
@@ -114,7 +114,7 @@ public class KubernetesClientTest : IntegrationTestBase, IDisposable
         _objects.Add(config1);
         _objects.Add(config2);
 
-        var configs = _client.List<V1ConfigMap>("default");
+        var (_, configs) = _client.List<V1ConfigMap>("default");
 
         // there are _at least_ 2 config maps (the two that were created)
         configs.Count.Should().BeGreaterOrEqualTo(2);
@@ -141,12 +141,12 @@ public class KubernetesClientTest : IntegrationTestBase, IDisposable
             });
         _objects.Add(config1);
 
-        var configs = _client.List<V1ConfigMap>("default");
+        var (_, configs) = _client.List<V1ConfigMap>("default");
         configs.Count.Should().BeGreaterOrEqualTo(2);
 
         _client.Delete(config2);
 
-        configs = _client.List<V1ConfigMap>("default");
+        (_, configs) = _client.List<V1ConfigMap>("default");
         configs.Count.Should().BeGreaterOrEqualTo(1);
     }
 

--- a/test/KubeOps.KubernetesClient.Test/KubernetesClientAsync.Test.cs
+++ b/test/KubeOps.KubernetesClient.Test/KubernetesClientAsync.Test.cs
@@ -114,7 +114,7 @@ public class KubernetesClientAsyncTest : IntegrationTestBase, IDisposable
         _objects.Add(config1);
         _objects.Add(config2);
 
-        var configs = await _client.ListAsync<V1ConfigMap>("default");
+        var (_, configs) = await _client.ListAsync<V1ConfigMap>("default");
 
         // there are _at least_ 2 config maps (the two that were created)
         configs.Count.Should().BeGreaterOrEqualTo(2);
@@ -141,12 +141,12 @@ public class KubernetesClientAsyncTest : IntegrationTestBase, IDisposable
             });
         _objects.Add(config1);
 
-        var configs = await _client.ListAsync<V1ConfigMap>("default");
+        var (_, configs) = await _client.ListAsync<V1ConfigMap>("default");
         configs.Count.Should().BeGreaterOrEqualTo(2);
 
         await _client.DeleteAsync(config2);
 
-        configs = await _client.ListAsync<V1ConfigMap>("default");
+        (_, configs) = await _client.ListAsync<V1ConfigMap>("default");
         configs.Count.Should().BeGreaterOrEqualTo(1);
     }
 

--- a/test/KubeOps.Operator.Test/Finalizer/EntityFinalizer.Integration.Test.cs
+++ b/test/KubeOps.Operator.Test/Finalizer/EntityFinalizer.Integration.Test.cs
@@ -178,7 +178,7 @@ public class EntityFinalizerIntegrationTest : IntegrationTestBase
     public override async Task DisposeAsync()
     {
         await base.DisposeAsync();
-        var entities = await _client.ListAsync<V1OperatorIntegrationTestEntity>(_ns.Namespace);
+        var (_, entities) = await _client.ListAsync<V1OperatorIntegrationTestEntity>(_ns.Namespace);
         foreach (var e in entities)
         {
             if (e.Metadata.Finalizers is null)

--- a/test/KubeOps.Operator.Test/LeaderElector/LeaderAwareness.Integration.Test.cs
+++ b/test/KubeOps.Operator.Test/LeaderElector/LeaderAwareness.Integration.Test.cs
@@ -37,7 +37,8 @@ public class LeaderAwarenessIntegrationTest : IntegrationTestBase
     {
         await base.DisposeAsync();
         await _ns.DisposeAsync();
-        await _client.DeleteAsync(await _client.ListAsync<V1Lease>("default"));
+        var (_, r) = await _client.ListAsync<V1Lease>("default");
+        await _client.DeleteAsync(r);
         _client.Dispose();
     }
 


### PR DESCRIPTION
Added a new function `public Task WatchSafeAsync<TEntity>` to the KubernetesClient.
This will try to refresh the watch in case on transient errors, like connection drops triggered from the API server.

NOTE:
The `List..` methods from the KubernetesClient are changed to also return the `ResourceVersion` as this is now also used by the `WatchSafeAsync` function to keep track of the object version to be able to re-initialize the watch in case of such a transient error.

This (latest) version can also make use of _watch-bookmark_ events for better handling of ResourceVersion changes inside an active watcher.