### PR TITLE
fix: Leader election failure to restart

### DIFF
--- a/src/KubeOps.Operator/LeaderElection/LeaderElectionBackgroundService.cs
+++ b/src/KubeOps.Operator/LeaderElection/LeaderElectionBackgroundService.cs
@@ -88,6 +88,10 @@ internal sealed class LeaderElectionBackgroundService(ILogger<LeaderElectionBack
             {
                 await elector.RunUntilLeadershipLostAsync(_cts.Token);
             }
+            catch (OperationCanceledException) when (_cts.IsCancellationRequested)
+            {
+                // Ignore cancellation exceptions when we've been asked to stop.
+            }
             catch (Exception exception)
             {
                 logger.LogError(exception, "Failed to hold leadership.");

--- a/src/KubeOps.Operator/LeaderElection/LeaderElectionBackgroundService.cs
+++ b/src/KubeOps.Operator/LeaderElection/LeaderElectionBackgroundService.cs
@@ -26,7 +26,7 @@ internal sealed class LeaderElectionBackgroundService(LeaderElector elector)
         // Therefore, we use Task.Run() and put the work to queue. The passed cancellation token of the StartAsync
         // method is not used, because it would only cancel the scheduling (which we definitely don't want to cancel).
         // To make this intention explicit, CancellationToken.None gets passed.
-        _ = Task.Run(() => elector.RunUntilLeadershipLostAsync(_cts.Token), CancellationToken.None);
+        _ = Task.Run(() => elector.RunAndTryToHoldLeadershipForeverAsync(_cts.Token), CancellationToken.None);
 
         return Task.CompletedTask;
     }

--- a/src/KubeOps.Operator/Watcher/ResourceWatcher{TEntity}.cs
+++ b/src/KubeOps.Operator/Watcher/ResourceWatcher{TEntity}.cs
@@ -2,7 +2,6 @@ using System.Collections.Concurrent;
 using System.Net;
 using System.Runtime.Serialization;
 using System.Text.Json;
-using System.Threading;
 
 using k8s;
 using k8s.Models;

--- a/test/KubeOps.Operator.Test/KubeOps.Operator.Test.csproj
+++ b/test/KubeOps.Operator.Test/KubeOps.Operator.Test.csproj
@@ -7,6 +7,7 @@
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.9.2" />
         <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.9.2" />
+        <PackageReference Include="Moq" Version="4.20.70" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/KubeOps.Operator.Test/LeaderElector/LeaderElectionBackgroundService.Test.cs
+++ b/test/KubeOps.Operator.Test/LeaderElector/LeaderElectionBackgroundService.Test.cs
@@ -1,0 +1,58 @@
+﻿using FluentAssertions;
+
+using k8s.LeaderElection;
+
+using KubeOps.Operator.LeaderElection;
+
+using Microsoft.Extensions.Logging;
+
+using Moq;
+
+namespace KubeOps.Operator.Test.LeaderElector;
+
+public sealed class LeaderElectionBackgroundServiceTest
+{
+    [Fact]
+    public async Task Elector_Throws_Should_Retry()
+    {
+        // Arrange.
+        var logger = Mock.Of<ILogger<LeaderElectionBackgroundService>>();
+
+        var electionLock = Mock.Of<ILock>();
+
+        var electionLockSubsequentCallEvent = new AutoResetEvent(false);
+        bool hasElectionLockThrown = false;
+        Mock.Get(electionLock)
+            .Setup(electionLock => electionLock.GetAsync(It.IsAny<CancellationToken>()))
+            .Returns<CancellationToken>(
+                async cancellationToken =>
+                {
+                    if (hasElectionLockThrown)
+                    {
+                        // Signal to the test that a subsequent call has been made.
+                        electionLockSubsequentCallEvent.Set();
+
+                        // Delay returning for a long time, allowing the test to stop the background service, in turn cancelling the cancellation token.
+                        await Task.Delay(TimeSpan.FromSeconds(10), cancellationToken);
+                        throw new InvalidOperationException();
+                    }
+
+                    hasElectionLockThrown = true;
+                    throw new Exception("Unit test exception");
+                });
+
+        var leaderElectionConfig = new LeaderElectionConfig(electionLock);
+        var leaderElector = new k8s.LeaderElection.LeaderElector(leaderElectionConfig);
+
+        var leaderElectionBackgroundService = new LeaderElectionBackgroundService(logger, leaderElector);
+
+        // Act / Assert.
+        await leaderElectionBackgroundService.StartAsync(CancellationToken.None);
+
+        // Starting the background service should result in the lock attempt throwing, and then a subsequent attempt being made.
+        // Wait for the subsequent event to be signalled, if we time out the test fails.
+        electionLockSubsequentCallEvent.WaitOne(TimeSpan.FromMilliseconds(500)).Should().BeTrue();
+
+        await leaderElectionBackgroundService.StopAsync(CancellationToken.None);
+    }
+}

--- a/test/KubeOps.Operator.Test/Watcher/ResourceWatcher{TEntity}.Test.cs
+++ b/test/KubeOps.Operator.Test/Watcher/ResourceWatcher{TEntity}.Test.cs
@@ -1,0 +1,53 @@
+﻿using System.Runtime.CompilerServices;
+
+using k8s;
+using k8s.Models;
+
+using KubeOps.Abstractions.Builder;
+using KubeOps.KubernetesClient;
+using KubeOps.Operator.Queue;
+using KubeOps.Operator.Watcher;
+
+using Microsoft.Extensions.Logging;
+
+using Moq;
+
+namespace KubeOps.Operator.Test.Watcher;
+
+public sealed class ResourceWatcherTest
+{
+    [Fact]
+    public async Task Restarting_Watcher_Should_Trigger_New_Watch()
+    {
+        // Arrange.
+        var logger = Mock.Of<ILogger<ResourceWatcher<V1Pod>>>();
+        var serviceProvider = Mock.Of<IServiceProvider>();
+        var timedEntityQueue = new TimedEntityQueue<V1Pod>();
+        var operatorSettings = new OperatorSettings() { Namespace = "unit-test" };
+        var kubernetesClient = Mock.Of<IKubernetesClient>();
+
+        Mock.Get(kubernetesClient)
+            .Setup(client => client.WatchAsync<V1Pod>("unit-test", null, null, true, It.IsAny<CancellationToken>()))
+            .Returns<string?, string?, string?, bool?, CancellationToken>((_, _, _, _, cancellationToken) => WaitForCancellationAsync<(WatchEventType, V1Pod)>(cancellationToken));
+
+        var resourceWatcher = new ResourceWatcher<V1Pod>(logger, serviceProvider, timedEntityQueue, operatorSettings, kubernetesClient);
+
+        // Act.
+        // Start and stop the watcher.
+        await resourceWatcher.StartAsync(CancellationToken.None);
+        await resourceWatcher.StopAsync(CancellationToken.None);
+
+        // Restart the watcher.
+        await resourceWatcher.StartAsync(CancellationToken.None);
+
+        // Assert.
+        Mock.Get(kubernetesClient)
+            .Verify(client => client.WatchAsync<V1Pod>("unit-test", null, null, true, It.IsAny<CancellationToken>()), Times.Exactly(2));
+    }
+
+    private static async IAsyncEnumerable<T> WaitForCancellationAsync<T>([EnumeratorCancellation]CancellationToken cancellationToken)
+    {
+        await Task.Delay(Timeout.Infinite, cancellationToken);
+        yield return default!;
+    }
+}

--- a/test/KubeOps.Operator.Test/Watcher/ResourceWatcher{TEntity}.Test.cs
+++ b/test/KubeOps.Operator.Test/Watcher/ResourceWatcher{TEntity}.Test.cs
@@ -45,7 +45,7 @@ public sealed class ResourceWatcherTest
             .Verify(client => client.WatchAsync<V1Pod>("unit-test", null, null, true, It.IsAny<CancellationToken>()), Times.Exactly(2));
     }
 
-    private static async IAsyncEnumerable<T> WaitForCancellationAsync<T>([EnumeratorCancellation]CancellationToken cancellationToken)
+    private static async IAsyncEnumerable<T> WaitForCancellationAsync<T>([EnumeratorCancellation] CancellationToken cancellationToken)
     {
         await Task.Delay(Timeout.Infinite, cancellationToken);
         yield return default!;


### PR DESCRIPTION
Fixes #677.

This pull request fixes the following behavioral issues noted when testing a leader-aware operator with transient network issues:
 - In `LeaderElectionBackgroundService`, if `elector.RunUntilLeadershipLostAsync()` throws, the exception is not observed in the library and no further attempts to become the leader occur. The library now logs any unexpected exceptions and tries to become the leader again.
 -  A leader could not stop and then subsequently start being a leader once more due to cancellation token sources not being recreated. The library now disposes and recreates the cancellation token sources as required.
 - `LeaderAwareResourceWatcher<TEntity>.StoppedLeading` would erroneously pass a cancelled cancellation token to `ResourceWatcher<TEntity>`. The library now passes the `IHostApplicationLifetime.ApplicationStopped` token to the `ResourceWatcher<TEntity>` - we can assume that `ApplicationStopped` is a good indication that the stop should no longer be graceful.

Due to the nature of these issues I've only been able to add test coverage in the form of unit tests.
I've tested these changes in practice using [clumsy](https://jagt.github.io/clumsy/) and an AKS cluster.