### PR TITLE
Add support for generating CRD's for entities that contain other custom resources

### DIFF
--- a/src/KubeOps.Abstractions/Entities/Attributes/DescriptionAttribute.cs
+++ b/src/KubeOps.Abstractions/Entities/Attributes/DescriptionAttribute.cs
@@ -1,8 +1,7 @@
 ﻿namespace KubeOps.Abstractions.Entities.Attributes;
 
 /// <summary>
-/// Defines a description for a property. This precedes the description found in a
-/// XML documentation file.
+/// Defines a description for a property.
 /// </summary>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Class)]
 public class DescriptionAttribute(string description) : Attribute

--- a/src/KubeOps.Transpiler/Crds.cs
+++ b/src/KubeOps.Transpiler/Crds.cs
@@ -324,6 +324,11 @@ public static class Crds
             return context.MapEnumerationType(type, interfaces);
         }
 
+        if (type.BaseType?.Name == nameof(CustomKubernetesEntity) || type.BaseType?.Name == typeof(CustomKubernetesEntity<>).Name)
+        {
+            return context.MapObjectType(type);
+        }
+
         return type.BaseType?.FullName switch
         {
             "System.Object" => context.MapObjectType(type),

--- a/test/KubeOps.Transpiler.Test/Crds.Mlc.Test.cs
+++ b/test/KubeOps.Transpiler.Test/Crds.Mlc.Test.cs
@@ -45,6 +45,8 @@ public class CrdsMlcTest(MlcProvider provider) : TranspilerTestBase(provider)
     [InlineData(typeof(EnumerableKeyPairsEntity), "object", null, false)]
     [InlineData(typeof(IntstrOrStringEntity), null, null, false)]
     [InlineData(typeof(EmbeddedResourceEntity), "object", null, false)]
+    [InlineData(typeof(EmbeddedCustomResourceEntity), "object", null, false)]
+    [InlineData(typeof(EmbeddedCustomResourceGenericEntity), "object", null, false)]
     [InlineData(typeof(EmbeddedResourceListEntity), "array", null, false)]
     public void Should_Transpile_Entity_Type_Correctly(Type type, string? expectedType, string? expectedFormat,
         bool isNullable)
@@ -685,6 +687,30 @@ public class CrdsMlcTest(MlcProvider provider) : TranspilerTestBase(provider)
     private class EmbeddedResourceEntity : CustomKubernetesEntity
     {
         public V1Pod Property { get; set; } = null!;
+    }
+
+    [KubernetesEntity(Group = "testing.dev", ApiVersion = "v1", Kind = "TestEntity")]
+    private class EmbeddedCustomResourceEntity : CustomKubernetesEntity
+    {
+        public EmbeddedCustomResource Property { get; set; } = null!;
+    }
+
+    [KubernetesEntity(Group = "testing.dev", ApiVersion = "v1", Kind = "TestEntity")]
+    private class EmbeddedCustomResource : CustomKubernetesEntity
+    {
+        public string Property { get; set; } = string.Empty;
+    }
+
+    [KubernetesEntity(Group = "testing.dev", ApiVersion = "v1", Kind = "TestEntity")]
+    private class EmbeddedCustomResourceGenericEntity : CustomKubernetesEntity
+    {
+        public EmbeddedCustomResourceGeneric Property { get; set; } = null!;
+    }
+
+    [KubernetesEntity(Group = "testing.dev", ApiVersion = "v1", Kind = "TestEntity")]
+    private class EmbeddedCustomResourceGeneric : CustomKubernetesEntity<EmbeddedCustomResourceGeneric.EntitySpec>
+    {
+        public class EntitySpec;
     }
 
     [KubernetesEntity(Group = "testing.dev", ApiVersion = "v1", Kind = "TestEntity")]


### PR DESCRIPTION
This adds support for a CustomKubernetesEntity that has another CustomKubernetesEntity as a property. We use this for cluster resources that create namespaced versions, so we want the spec to match without having to duplicate the spec inside the parent CustomKubernetesEntity. https://github.com/Contrast-Security-OSS/agent-operator/blob/master/src/Contrast.K8s.AgentOperator/Entities/V1Beta1ClusterAgentConnection.cs

In previous versions of the sdk the generator supported this scenario but the current one errors out with `System.ArgumentException: The given type Contrast.K8s.AgentOperator.Entities.V1Beta1AgentConfiguration is not a valid Kubernetes entity.` inside the Map function. 

Also cleaned up the xml doc on the description attribute since the new generator doesn't support pulling the description from the xml summary.