### PR TITLE
Set KubeOps.Generator as a DevelopmentDependency

### DIFF
--- a/src/KubeOps.Generator/KubeOps.Generator.csproj
+++ b/src/KubeOps.Generator/KubeOps.Generator.csproj
@@ -1,10 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
         <IsRoslynComponent>true</IsRoslynComponent>
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
+        <DevelopmentDependency>true</DevelopmentDependency>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/KubeOps.Generator/README.md
+++ b/src/KubeOps.Generator/README.md
@@ -16,7 +16,10 @@ which results in the following `csproj` reference:
 
 ```xml
 <ItemGroup>
-    <PackageReference Include="KubeOps.Generator" Version="..." />
+    <PackageReference Include="KubeOps.Generator" Version="...">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
 </ItemGroup>
 ```
 


### PR DESCRIPTION
Fixes: #698 
This will cause `dotnet add package` to add this to the PackageReference automatically:
```
<PrivateAssets>all</PrivateAssets>
<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
```
It will also show on nuget.org:
![image](https://github.com/user-attachments/assets/4584297d-6356-4172-aff0-d418e2134807)

This flag is used by other source generators to fix the problem in #698

This flag is documented for .nuspec files but also works with `dotnet pack` in the csproj
![image](https://github.com/user-attachments/assets/5fae7fab-762d-4da9-8edf-974fa87c6456)


