### PR TITLE
updating to dotnet 9

### DIFF
--- a/examples/ConversionWebhookOperator/ConversionWebhookOperator.csproj
+++ b/examples/ConversionWebhookOperator/ConversionWebhookOperator.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <EnablePreviewFeatures>true</EnablePreviewFeatures>

--- a/examples/Operator/Operator.csproj
+++ b/examples/Operator/Operator.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>

--- a/examples/WebhookOperator/WebhookOperator.csproj
+++ b/examples/WebhookOperator/WebhookOperator.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <IsPackable>false</IsPackable>

--- a/src/KubeOps.Abstractions/KubeOps.Abstractions.csproj
+++ b/src/KubeOps.Abstractions/KubeOps.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/KubeOps.Cli/KubeOps.Cli.csproj
+++ b/src/KubeOps.Cli/KubeOps.Cli.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
         <EnablePreviewFeatures>true</EnablePreviewFeatures>
     </PropertyGroup>
 

--- a/src/KubeOps.KubernetesClient/KubeOps.KubernetesClient.csproj
+++ b/src/KubeOps.KubernetesClient/KubeOps.KubernetesClient.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/KubeOps.Operator.Web/Certificates/CertificateExtensions.cs
+++ b/src/KubeOps.Operator.Web/Certificates/CertificateExtensions.cs
@@ -49,9 +49,16 @@ public static class CertificateExtensions
             _ => throw new NotImplementedException($"{serverPair.Key} is not implemented for {nameof(CopyServerCertWithPrivateKey)}"),
         };
 
+#if NET9_0_OR_GREATER
+        return X509CertificateLoader.LoadPkcs12(
+            temp.Export(X509ContentType.Pfx, password),
+            password,
+            X509KeyStorageFlags.Exportable | X509KeyStorageFlags.PersistKeySet);
+#else
         return new X509Certificate2(
             temp.Export(X509ContentType.Pfx, password),
             password,
             X509KeyStorageFlags.Exportable | X509KeyStorageFlags.PersistKeySet);
+#endif
     }
 }

--- a/src/KubeOps.Operator.Web/KubeOps.Operator.Web.csproj
+++ b/src/KubeOps.Operator.Web/KubeOps.Operator.Web.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/KubeOps.Operator/KubeOps.Operator.csproj
+++ b/src/KubeOps.Operator/KubeOps.Operator.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/KubeOps.Transpiler/KubeOps.Transpiler.csproj
+++ b/src/KubeOps.Transpiler/KubeOps.Transpiler.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>

--- a/test/KubeOps.Operator.Web.Test/Builder/OperatorBuilderExtensions.Test.cs
+++ b/test/KubeOps.Operator.Web.Test/Builder/OperatorBuilderExtensions.Test.cs
@@ -1,4 +1,6 @@
-﻿using FluentAssertions;
+﻿using System.Runtime.Versioning;
+
+using FluentAssertions;
 
 using KubeOps.Abstractions.Builder;
 using KubeOps.Abstractions.Certificates;
@@ -12,7 +14,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 namespace KubeOps.Operator.Web.Test.Builder;
-
+[RequiresPreviewFeatures]
 public class OperatorBuilderExtensionsTest : IDisposable
 {
     private readonly IOperatorBuilder _builder = new OperatorBuilder(new ServiceCollection(), new());

--- a/test/KubeOps.Operator.Web.Test/IntegrationTestCollection.cs
+++ b/test/KubeOps.Operator.Web.Test/IntegrationTestCollection.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 
 using k8s;
 using k8s.Models;
@@ -111,7 +112,7 @@ public sealed class MlcProvider : IAsyncLifetime
         return Task.CompletedTask;
     }
 }
-
+[RequiresPreviewFeatures]
 public sealed class ApplicationProvider : IAsyncLifetime
 {
     private WebApplication? _app;


### PR DESCRIPTION
This will allow us to also support .net 9 that was release in Nov 2024. namely, the CLI will now function in .net 9 and not need dual SDKs

cc: @buehler 