### PR TITLE
fix: x-kubernetes-preserve-unknown-fields incorrectly applied on List<T>

### DIFF
--- a/src/KubeOps.Abstractions/Entities/Attributes/PreserveUnknownFieldsAttribute.cs
+++ b/src/KubeOps.Abstractions/Entities/Attributes/PreserveUnknownFieldsAttribute.cs
@@ -4,5 +4,5 @@
 /// Defines that a property should keep unknown fields
 /// so that kubernetes does not purge additional structures.
 /// </summary>
-[AttributeUsage(AttributeTargets.Property)]
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Class)]
 public class PreserveUnknownFieldsAttribute : Attribute;

--- a/src/KubeOps.Transpiler/Crds.cs
+++ b/src/KubeOps.Transpiler/Crds.cs
@@ -422,6 +422,7 @@ public static class Crds
                         { Count: > 0 } p => p,
                         _ => null,
                     },
+                    XKubernetesPreserveUnknownFields = type.GetCustomAttributeData<PreserveUnknownFieldsAttribute>() != null ? true : null,
                 };
         }
     }

--- a/test/KubeOps.Transpiler.Test/Crds.Mlc.Test.cs
+++ b/test/KubeOps.Transpiler.Test/Crds.Mlc.Test.cs
@@ -342,6 +342,24 @@ public class CrdsMlcTest(MlcProvider provider) : TranspilerTestBase(provider)
     }
 
     [Fact]
+    public void Should_Set_Preserve_Unknown_Fields_On_Classes()
+    {
+        var crd = _mlc.Transpile(typeof(UnknownFieldsEntity));
+
+        var specProperties = crd.Spec.Versions.First().Schema.OpenAPIV3Schema.Properties["spec"];
+        specProperties.XKubernetesPreserveUnknownFields.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Should_Set_Preserve_Unknown_Fields_On_ObjectLists()
+    {
+        var crd = _mlc.Transpile(typeof(UnknownFieldsListEntity));
+
+        var specProperties = (V1JSONSchemaProps)crd.Spec.Versions.First().Schema.OpenAPIV3Schema.Properties["spec"].Properties["propertyList"].Items;
+        specProperties.XKubernetesPreserveUnknownFields.Should().BeTrue();
+    }
+
+    [Fact]
     public void Should_Not_Set_Preserve_Unknown_Fields_On_Generic_Dictionaries()
     {
         var crd = _mlc.Transpile(typeof(DictionaryEntity));
@@ -686,6 +704,25 @@ public class CrdsMlcTest(MlcProvider provider) : TranspilerTestBase(provider)
     private class SimpleDictionaryEntity : CustomKubernetesEntity
     {
         public IDictionary Property { get; set; } = null!;
+    }
+
+    [KubernetesEntity(Group = "testing.dev", ApiVersion = "v1", Kind = "TestEntity")]
+    private class UnknownFieldsEntity : CustomKubernetesEntity<UnknownFieldsEntity.EntitySpec>
+    {
+        [PreserveUnknownFields]
+        public class EntitySpec;
+    }
+
+    [KubernetesEntity(Group = "testing.dev", ApiVersion = "v1", Kind = "TestEntity")]
+    private class UnknownFieldsListEntity : CustomKubernetesEntity<UnknownFieldsListEntity.EntitySpec>
+    {
+        public class EntitySpec
+        {
+            public List<ObjectList> PropertyList { get; set; } = null!;
+
+            [PreserveUnknownFields]
+            public class ObjectList;
+        }
     }
 
     [KubernetesEntity(Group = "testing.dev", ApiVersion = "v1", Kind = "TestEntity")]


### PR DESCRIPTION
### Describe the bug

PreserveUnknownFieldsAttribute can currently only be applied to properties. If within my CRD I have a List<T> and I set the attribute, it will render in the CRD at the items level, not within the object itself.

### To reproduce

```csharp
[KubernetesEntity(Group = "test.io", Kind = "Test", ApiVersion = "v1")]
public partial class TestCrd : CustomKubernetesEntity<TestSpec> { }

public class TestSpec
{
    [PreserveUnknownFields]
    public List<Item> Items { get; set; } = default!;
}

public class Item
{
    public string Name { get; set; } = default!;
}
```

Generates
```yaml
  - name: v1
    schema:
      openAPIV3Schema:
        properties:
          spec:
            properties:
              items:
                items:
                  properties:
                    name:
                      type: string
                  type: object
                type: array
                x-kubernetes-preserve-unknown-fields: true
            type: object
        type: object
```

### Expected behavior

x-kubernetes-preserve-unknown-fields: true should be applied to the object within items
```yaml
  - name: v1
    schema:
      openAPIV3Schema:
        properties:
          spec:
            properties:
              items:
                items:
                  properties:
                    name:
                      type: string
                  type: object
                  x-kubernetes-preserve-unknown-fields: true
                type: array
            type: object
        type: object
```
To achieve this result, the attribute should be allowed on classes
```csharp
[KubernetesEntity(Group = "test.io", Kind = "Test", ApiVersion = "v1")]
public partial class TestCrd : CustomKubernetesEntity<TestSpec> { }

public class TestSpec
{
    public List<Item> Items { get; set; } = default!;
}

[PreserveUnknownFields]
public class Item
{
    public string Name { get; set; } = default!;
}
```