### PR TITLE
feat: Added option to provide an accessable docker image through a CLI option

### DIFF
--- a/src/KubeOps.Cli/Commands/Generator/OperatorGenerator.cs
+++ b/src/KubeOps.Cli/Commands/Generator/OperatorGenerator.cs
@@ -30,6 +30,8 @@ internal static class OperatorGenerator
                     Options.OutputPath,
                     Options.SolutionProjectRegex,
                     Options.TargetFramework,
+                    Options.AccessibleDockerImage,
+                    Options.AccessibleDockerTag,
                     Arguments.OperatorName,
                     Arguments.SolutionOrProjectFile,
                 };
@@ -46,6 +48,8 @@ internal static class OperatorGenerator
         var file = ctx.ParseResult.GetValueForArgument(Arguments.SolutionOrProjectFile);
         var outPath = ctx.ParseResult.GetValueForOption(Options.OutputPath);
         var format = ctx.ParseResult.GetValueForOption(Options.OutputFormat);
+        var dockerImage = ctx.ParseResult.GetValueForOption(Options.AccessibleDockerImage)!;
+        var dockerImageTag = ctx.ParseResult.GetValueForOption(Options.AccessibleDockerTag)!;
 
         var result = new ResultOutput(AnsiConsole.Console, format);
         AnsiConsole.Console.WriteLine("Generate operator resources.");
@@ -121,7 +125,7 @@ internal static class OperatorGenerator
                 Images =
                     new List<KustomizationImage>
                     {
-                        new() { Name = "operator", NewName = "accessible-docker-image", NewTag = "latest", },
+                        new() { Name = "operator", NewName = dockerImage, NewTag = dockerImageTag, },
                     },
                 ConfigMapGenerator = hasWebhooks
                     ? new List<KustomizationConfigMapGenerator>

--- a/src/KubeOps.Cli/Options.cs
+++ b/src/KubeOps.Cli/Options.cs
@@ -40,4 +40,14 @@ internal static class Options
         ["--clear-out"],
         () => false,
         description: "Clear the output path before generating resources.");
+
+    public static readonly Option<string> AccessibleDockerImage = new(
+        "--docker-image",
+        () => "accessible-docker-image",
+        description: "An accessible docker image to deploy");
+
+    public static readonly Option<string> AccessibleDockerTag = new(
+        "--docker-image-tag",
+        () => "latest",
+        description: "Tag for an accessible docker image to deploy");
 }


### PR DESCRIPTION
The option to provide an accessible CLI image through `--docker-image` and its tag through `--docker-tag` has been added to the generate command. This just makes things a bit nicer generate instead of having to do a second patch over the top of the generated manifest when, for example, generating a release for an operator we would no longer need to do a string replacement to or patch to correct the docker image.

closes #863 