### PR TITLE
feat: Allow for providing docker image & tag through msbuild properties

### DIFF
--- a/src/KubeOps.Operator/Build/KubeOps.Operator.targets
+++ b/src/KubeOps.Operator/Build/KubeOps.Operator.targets
@@ -24,7 +24,15 @@
     <Target Name="GenerateKustomizationConfig" DependsOnTargets="BaseConfig">
         <Message Text="Generating Kustomization Configuration" Importance="high" />
         <Message Text="Configuration path: $(KubeOpsConfigOut)" Importance="normal" />
-        <Exec Command="$(KubeOpsCli) generate operator --out $(KubeOpsConfigOut) $(OperatorName) $(MSBuildProjectFullPath)" />
+        <Message Condition="'$(DockerImage)' != ''" Text="Using docker image: $(DockerImage)" Importance="normal" />
+        <Message Condition="'$(DockerImageTag)' != ''" Text="Using docker image tag: $(DockerImageTag)" Importance="normal" />
+        
+        <PropertyGroup>
+            <DockerImage Condition="'$(DockerImage)' != ''">--docker-image $(DockerImage)</DockerImage>
+            <DockerImageTag Condition="'$(DockerImageTag)' != ''">--docker-image-tag $(DockerImageTag)</DockerImageTag>
+        </PropertyGroup>
+        
+        <Exec Command="$(KubeOpsCli) generate operator --out $(KubeOpsConfigOut) $(DockerImage) $(DockerImageTag) $(OperatorName) $(MSBuildProjectFullPath)" />
     </Target>
 
     <Target Name="GenerateOperatorResources"


### PR DESCRIPTION
Following #864 the cli options to set a docker image can be provided as MSBuild properties.