### PR TITLE
Removing the nested Pair

### DIFF
--- a/src/KubeOps.Abstractions/Kustomize/KustomizationCommonLabels.cs
+++ b/src/KubeOps.Abstractions/Kustomize/KustomizationCommonLabels.cs
@@ -9,7 +9,7 @@ public class KustomizationCommonLabels
     {
         foreach (var keyValuePair in pairs)
         {
-            Pairs.Add(keyValuePair.Key,keyValuePair.Value);
+            Pairs.Add(keyValuePair.Key, keyValuePair.Value);
         }
     }
 

--- a/src/KubeOps.Abstractions/Kustomize/KustomizationCommonLabels.cs
+++ b/src/KubeOps.Abstractions/Kustomize/KustomizationCommonLabels.cs
@@ -7,11 +7,19 @@ public class KustomizationCommonLabels
 {
     public KustomizationCommonLabels(IDictionary<string, string> pairs)
     {
-        Pairs.Add(new KustomizationCommonLabelsPair() { Pairs = pairs });
+        foreach (var keyValuePair in pairs)
+        {
+            Pairs.Add(keyValuePair.Key,keyValuePair.Value);
+        }
     }
+
+    /// <summary>
+    /// Include selectors.
+    /// </summary>
+    public bool IncludeSelectors { get; init; } = true;
 
     /// <summary>
     /// A list of common labels.
     /// </summary>
-    public List<KustomizationCommonLabelsPair> Pairs { get; set; } = new List<KustomizationCommonLabelsPair>();
+    public KustomizationCommonLabelsPair Pairs { get; set; } = new KustomizationCommonLabelsPair();
 }

--- a/src/KubeOps.Abstractions/Kustomize/KustomizationCommonLabelsPair.cs
+++ b/src/KubeOps.Abstractions/Kustomize/KustomizationCommonLabelsPair.cs
@@ -1,14 +1,3 @@
 ﻿namespace KubeOps.Abstractions.Kustomize;
 
-public class KustomizationCommonLabelsPair
-{
-    /// <summary>
-    /// A dictionary of common labels.
-    /// </summary>
-    public IDictionary<string, string>? Pairs { get; set; }
-
-    /// <summary>
-    /// Include selectors.
-    /// </summary>
-    public bool IncludeSelectors { get; init; } = true;
-}
+public class KustomizationCommonLabelsPair: Dictionary<string, string> { }

--- a/src/KubeOps.Abstractions/Kustomize/KustomizationCommonLabelsPair.cs
+++ b/src/KubeOps.Abstractions/Kustomize/KustomizationCommonLabelsPair.cs
@@ -1,3 +1,3 @@
 ﻿namespace KubeOps.Abstractions.Kustomize;
 
-public class KustomizationCommonLabelsPair: Dictionary<string, string> { }
+public class KustomizationCommonLabelsPair : Dictionary<string, string>;


### PR DESCRIPTION
This pull request refactors the handling of common labels in the `KustomizationCommonLabels` class and its associated `KustomizationCommonLabelsPair` class to simplify the data structure and improve usability. The most important changes include replacing the `KustomizationCommonLabelsPair` class with a direct inheritance from `Dictionary<string, string>` and updating the `KustomizationCommonLabels` class to reflect this change.

### Refactoring of common labels handling:

* [`src/KubeOps.Abstractions/Kustomize/KustomizationCommonLabelsPair.cs`](diffhunk://#diff-500791e44853948e64cc50e1fbd37cb5ba56cef839636e30ab119a7ea54ba332L3-R3): Simplified the `KustomizationCommonLabelsPair` class by making it directly inherit from `Dictionary<string, string>`, removing its properties and methods.

* [`src/KubeOps.Abstractions/Kustomize/KustomizationCommonLabels.cs`](diffhunk://#diff-9ff89020ff654e0389952b6f3075c61c281221e538f32dd9854c9586e5c1d469L10-R24): Updated the `Pairs` property in `KustomizationCommonLabels` to use the new `KustomizationCommonLabelsPair` structure. Replaced the initialization logic to add key-value pairs directly to the dictionary. Removed the `IncludeSelectors` property from `KustomizationCommonLabelsPair` and reintroduced it as a property in `KustomizationCommonLabels` with a default value of `true`.

This is a fix for https://github.com/buehler/dotnet-operator-sdk/issues/868