### PR TITLE
Update .NET framework support to .NET 8.0+

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ detailed documentation, head to the [GitHub Pages](https://buehler.github.io/dot
 
 ## Packages
 
-All packages support .NET6.0 and higher. The reason is that modern C# features are
-used and client libraries are still possible for .NET 6.0 and up.
+All packages support .NET8.0 and higher. The reason is that modern C# features are
+used and client libraries are optimized for .NET 8.0 and up.
 Also, the KubernetesClient package follows the same strategy regarding the
-older framework versions.
+framework versions.
 The following packages exist:
 
 | Package                                                              | Description                                            | Latest Version                                                                                                                                                          |

--- a/src/KubeOps.Abstractions/KubeOps.Abstractions.csproj
+++ b/src/KubeOps.Abstractions/KubeOps.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/KubeOps.Cli/Commands/Management/Install.cs
+++ b/src/KubeOps.Cli/Commands/Management/Install.cs
@@ -78,7 +78,7 @@ internal static class Install
                     case { Items: [var existing] }:
                         console.MarkupLineInterpolated(
                             $"""[yellow]CRD "{crd.Spec.Group}/{crd.Spec.Names.Kind}" already exists.[/]""");
-                        if (!force && !console.Confirm("[yellow]Should the CRD be overwritten?[/]"))
+                        if (!force && !await console.ConfirmAsync("[yellow]Should the CRD be overwritten?[/]"))
                         {
                             ctx.ExitCode = ExitCodes.Aborted;
                             return;

--- a/src/KubeOps.Cli/Commands/Management/Uninstall.cs
+++ b/src/KubeOps.Cli/Commands/Management/Uninstall.cs
@@ -63,7 +63,7 @@ internal static class Uninstall
         }
 
         console.WriteLine($"Found {crds.Count} CRDs.");
-        if (!force && !console.Confirm("[red]Should the CRDs be uninstalled?[/]", false))
+        if (!force && !await console.ConfirmAsync("[red]Should the CRDs be uninstalled?[/]", false))
         {
             ctx.ExitCode = ExitCodes.Aborted;
             return;

--- a/src/KubeOps.Cli/KubeOps.Cli.csproj
+++ b/src/KubeOps.Cli/KubeOps.Cli.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
         <EnablePreviewFeatures>true</EnablePreviewFeatures>
     </PropertyGroup>
 

--- a/src/KubeOps.Cli/KubeOps.Cli.csproj
+++ b/src/KubeOps.Cli/KubeOps.Cli.csproj
@@ -24,8 +24,8 @@
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.9.2" />
         <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.9.2" />
-        <PackageReference Include="Spectre.Console" Version="0.49.1" />
-        <PackageReference Include="Spectre.Console.Analyzer" Version="0.49.1">
+        <PackageReference Include="Spectre.Console" Version="0.50.0" />
+        <PackageReference Include="Spectre.Console.Analyzer" Version="0.50.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/KubeOps.Cli/Transpilation/AssemblyLoader.cs
+++ b/src/KubeOps.Cli/Transpilation/AssemblyLoader.cs
@@ -183,10 +183,6 @@ internal static partial class AssemblyLoader
         .SelectMany(a => a.DefinedTypes)
         .Where(t => !t.IsInterface && !t.IsAbstract && !t.IsGenericType);
 
-#if NET7_0_OR_GREATER
-    [GeneratedRegex(".*")]
+[GeneratedRegex(".*")]
     private static partial Regex DefaultRegex();
-#else
-    private static Regex DefaultRegex() => new(".*");
-#endif
 }

--- a/src/KubeOps.Cli/Transpilation/TfmComparer.cs
+++ b/src/KubeOps.Cli/Transpilation/TfmComparer.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.RegularExpressions;
+using System.Text.RegularExpressions;
 
 namespace KubeOps.Cli.Transpilation;
 
@@ -7,17 +7,10 @@ namespace KubeOps.Cli.Transpilation;
 /// </summary>
 internal sealed partial class TfmComparer : IComparer<string>
 {
-#if NET7_0_OR_GREATER
     [GeneratedRegex(
-        "[(]?(?<tfm>(?<name>(netcoreapp|net|netstandard){1})(?<major>[0-9]+)[.](?<minor>[0-9]+))[)]?",
+        "[(]?(?<tfm>(?<n>(netcoreapp|net|netstandard){1})(?<major>[0-9]+)[.](?<minor>[0-9]+))[)]?",
         RegexOptions.Compiled)]
     public static partial Regex TfmRegex();
-#else
-    public static Regex TfmRegex() =>
-        new(
-            "[(]?(?<tfm>(?<name>(netcoreapp|net|netstandard){1})(?<major>[0-9]+)[.](?<minor>[0-9]+))[)]?",
-            RegexOptions.Compiled);
-#endif
 
     public int Compare(string? x, string? y)
     {

--- a/src/KubeOps.KubernetesClient/KubeOps.KubernetesClient.csproj
+++ b/src/KubeOps.KubernetesClient/KubeOps.KubernetesClient.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/KubeOps.Operator.Web/KubeOps.Operator.Web.csproj
+++ b/src/KubeOps.Operator.Web/KubeOps.Operator.Web.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/KubeOps.Operator/KubeOps.Operator.csproj
+++ b/src/KubeOps.Operator/KubeOps.Operator.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/KubeOps.Operator/LeaderElection/LeaderElectionBackgroundService.cs
+++ b/src/KubeOps.Operator/LeaderElection/LeaderElectionBackgroundService.cs
@@ -48,11 +48,7 @@ internal sealed class LeaderElectionBackgroundService(ILogger<LeaderElectionBack
             return;
         }
 
-#if NET8_0_OR_GREATER
         await _cts.CancelAsync();
-#else
-        _cts.Cancel();
-#endif
 
         if (_leadershipTask is not null)
         {

--- a/src/KubeOps.Operator/Queue/EntityRequeueBackgroundService.cs
+++ b/src/KubeOps.Operator/Queue/EntityRequeueBackgroundService.cs
@@ -44,12 +44,7 @@ internal sealed class EntityRequeueBackgroundService<TEntity>(
             return Task.CompletedTask;
         }
 
-#if NET8_0_OR_GREATER
         return _cts.CancelAsync();
-#else
-        _cts.Cancel();
-        return Task.CompletedTask;
-#endif
     }
 
     public void Dispose()

--- a/src/KubeOps.Operator/Watcher/ResourceWatcher{TEntity}.cs
+++ b/src/KubeOps.Operator/Watcher/ResourceWatcher{TEntity}.cs
@@ -62,11 +62,7 @@ internal class ResourceWatcher<TEntity>(
             return;
         }
 
-#if NET8_0_OR_GREATER
         await _cancellationTokenSource.CancelAsync();
-#else
-        _cancellationTokenSource.Cancel();
-#endif
         if (_eventWatcher is not null)
         {
             await _eventWatcher.WaitAsync(cancellationToken);

--- a/src/KubeOps.Transpiler/KubeOps.Transpiler.csproj
+++ b/src/KubeOps.Transpiler/KubeOps.Transpiler.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/KubeOps.Transpiler/Kubernetes/KubernetesVersionComparer.cs
+++ b/src/KubeOps.Transpiler/Kubernetes/KubernetesVersionComparer.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.RegularExpressions;
+using System.Text.RegularExpressions;
 
 namespace KubeOps.Transpiler.Kubernetes;
 
@@ -10,11 +10,6 @@ namespace KubeOps.Transpiler.Kubernetes;
 /// </summary>
 public sealed partial class KubernetesVersionComparer : IComparer<string>
 {
-#if !NET7_0_OR_GREATER
-    private static readonly Regex KubernetesVersionRegex =
-        new("^v(?<major>[0-9]+)((?<stream>alpha|beta)(?<minor>[0-9]+))?$", RegexOptions.Compiled);
-#endif
-
     private enum Stream
     {
         Alpha = 1,
@@ -29,21 +24,13 @@ public sealed partial class KubernetesVersionComparer : IComparer<string>
             return StringComparer.CurrentCulture.Compare(x, y);
         }
 
-#if NET7_0_OR_GREATER
         var matchX = KubernetesVersionRegex().Match(x);
-#else
-        var matchX = KubernetesVersionRegex.Match(x);
-#endif
         if (!matchX.Success)
         {
             return StringComparer.CurrentCulture.Compare(x, y);
         }
 
-#if NET7_0_OR_GREATER
         var matchY = KubernetesVersionRegex().Match(y);
-#else
-        var matchY = KubernetesVersionRegex.Match(y);
-#endif
         if (!matchY.Success)
         {
             return StringComparer.CurrentCulture.Compare(x, y);
@@ -54,10 +41,8 @@ public sealed partial class KubernetesVersionComparer : IComparer<string>
         return versionX.CompareTo(versionY);
     }
 
-#if NET7_0_OR_GREATER
     [GeneratedRegex("^v(?<major>[0-9]+)((?<stream>alpha|beta)(?<minor>[0-9]+))?$", RegexOptions.Compiled)]
     private static partial Regex KubernetesVersionRegex();
-#endif
 
     private Version ExtractVersion(Match match)
     {

--- a/test/KubeOps.Cli.Test/KubeOps.Cli.Test.csproj
+++ b/test/KubeOps.Cli.Test/KubeOps.Cli.Test.csproj
@@ -11,6 +11,6 @@
         <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.13.0" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.13.0" />
-        <PackageReference Include="Spectre.Console.Testing" Version="0.49.1" />
+        <PackageReference Include="Spectre.Console.Testing" Version="0.50.0" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR updates the codebase to support only .NET 8.0 and higher by:

- Removing NET6_0 and NET7_0 conditional compilation branches
- Updating all project files to target only .NET 8.0 and .NET 9.0
- Updating the README to state that all packages support .NET 8.0 and higher
- Simplifying code by removing conditional compilation directives for older .NET versions

This change aligns with modern .NET development practices and reduces maintenance overhead by focusing on current and future .NET versions.