### PR TITLE
Add `AllExplicit` RBAC verb & state all default V1Lease RBAC verbs explicitly

### DIFF
--- a/src/KubeOps.Abstractions/Rbac/RbacVerbs.cs
+++ b/src/KubeOps.Abstractions/Rbac/RbacVerbs.cs
@@ -50,4 +50,9 @@ public enum RbacVerb
     /// Delete resources on the api.
     /// </summary>
     Delete = 1 << 7,
+
+    /// <summary>
+    /// All possible permissions (defined explicitly).
+    /// </summary>
+    AllExplicit = 1 << 8,
 }

--- a/src/KubeOps.Cli/Generators/RbacGenerator.cs
+++ b/src/KubeOps.Cli/Generators/RbacGenerator.cs
@@ -36,6 +36,6 @@ internal class RbacGenerator(MetadataLoadContext parser,
     }
 
     [EntityRbac(typeof(Corev1Event), Verbs = RbacVerb.Get | RbacVerb.List | RbacVerb.Create | RbacVerb.Update)]
-    [EntityRbac(typeof(V1Lease), Verbs = RbacVerb.All)]
+    [EntityRbac(typeof(V1Lease), Verbs = RbacVerb.AllExplicit)]
     private sealed class DefaultRbacAttributes;
 }

--- a/src/KubeOps.Transpiler/Rbac.cs
+++ b/src/KubeOps.Transpiler/Rbac.cs
@@ -83,9 +83,14 @@ public static class Rbac
     {
         RbacVerb.None => Array.Empty<string>(),
         _ when verbs.HasFlag(RbacVerb.All) => ["*"],
+        _ when verbs.HasFlag(RbacVerb.AllExplicit) =>
+            Enum.GetValues<RbacVerb>()
+                .Where(v => v != RbacVerb.All && v != RbacVerb.None && v != RbacVerb.AllExplicit)
+                .Select(v => v.ToString().ToLowerInvariant())
+                .ToArray(),
         _ =>
             Enum.GetValues<RbacVerb>()
-                .Where(v => verbs.HasFlag(v) && v != RbacVerb.All && v != RbacVerb.None)
+                .Where(v => verbs.HasFlag(v) && v != RbacVerb.All && v != RbacVerb.None && v != RbacVerb.AllExplicit)
                 .Select(v => v.ToString().ToLowerInvariant())
                 .ToArray(),
     };

--- a/test/KubeOps.Transpiler.Test/Rbac.Mlc.Test.cs
+++ b/test/KubeOps.Transpiler.Test/Rbac.Mlc.Test.cs
@@ -83,6 +83,15 @@ public class RbacMlcTest(MlcProvider provider) : TranspilerTestBase(provider)
         roles.Should().HaveCount(5);
     }
 
+    [Fact]
+    public void Should_Correctly_Calculate_All_Verbs_Explicitly()
+    {
+        var role = _mlc
+            .Transpile(_mlc.GetContextType<RbacTest6>().GetCustomAttributesData<EntityRbacAttribute>()).ToList().First();
+        role.Resources.Should().Contain("leases");
+        role.Verbs.Should().Contain(new[] { "get", "list", "watch", "create", "update", "patch", "delete" });
+    }
+
     [KubernetesEntity(Group = "test", ApiVersion = "v1")]
     [EntityRbac(typeof(RbacTest1), Verbs = RbacVerb.Get)]
     [EntityRbac(typeof(RbacTest1), Verbs = RbacVerb.Update)]
@@ -114,6 +123,10 @@ public class RbacMlcTest(MlcProvider provider) : TranspilerTestBase(provider)
     [EntityRbac(typeof(V1Service), Verbs = RbacVerb.All)]
     [EntityRbac(typeof(V1Lease), Verbs = RbacVerb.All)]
     public class RbacTest5 : CustomKubernetesEntity;
+
+    [KubernetesEntity(Group = "test", ApiVersion = "v1")]
+    [EntityRbac(typeof(V1Lease), Verbs = RbacVerb.AllExplicit)]
+    public class RbacTest6 : CustomKubernetesEntity;
 
     [KubernetesEntity(Group = "test", ApiVersion = "v1")]
     [GenericRbac(Urls = ["url", "foobar"], Resources = ["configmaps"], Groups = ["group"],


### PR DESCRIPTION
## Overview

Adds new `AllExplicit` RBAC verb to state all RBAC verbs explicitly, alternatively to the current `All` RBAC verb that generates a `*` (wildcard) RBAC verb.

### Motivation

As described [here](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#referring-to-resources), using wildcards in verb entries could result in overly permissive access being granted. The [principle of least privilege](https://kubernetes.io/docs/concepts/security/rbac-good-practices/#least-privilege) should be employed, using specific verbs to ensure only the permissions required for the workload to function correctly are applied.

