### PR TITLE
feat: add namespace to logging scope and make ResourceWatcher more extensible

### DIFF
--- a/src/KubeOps.Operator/Queue/TimedEntityQueue.cs
+++ b/src/KubeOps.Operator/Queue/TimedEntityQueue.cs
@@ -10,7 +10,7 @@ namespace KubeOps.Operator.Queue;
 /// The given enumerable only contains items that should be considered for reconciliations.
 /// </summary>
 /// <typeparam name="TEntity">The type of the inner entity.</typeparam>
-internal sealed class TimedEntityQueue<TEntity> : IDisposable
+public sealed class TimedEntityQueue<TEntity> : IDisposable
     where TEntity : IKubernetesObject<V1ObjectMeta>
 {
     // A shared task factory for all the created tasks.


### PR DESCRIPTION
Hi @buehler,

I have a small adjustment here. Two things that are relevant for us:

1) I’ve added the namespace to the logging scope — since we manage multiple namespaces via the CRDs, this gives us better context in the logs and helps us assign log entries more accurately.

2) I made the ResourceWatcher public and the OnEventAsync method protected virtual, so it can be overridden. Given the number of namespaces we manage, we want to allow developers to take over the lead for a single namespace for debugging purposes — but not the entire lead. Therefore, we can’t use the LeaderAwareResourceWatcher as-is; instead, we need a customized ResourceWatcher that checks for leadership on a specific namespace.

I hope these changes align with your design principles.