### PR TITLE
feat: introduce `EntityLoggingScope` to support scopes as key-value pairs inside custom properties of application insights

### DIFF
--- a/src/KubeOps.Operator/Logging/EntityLoggingScope.cs
+++ b/src/KubeOps.Operator/Logging/EntityLoggingScope.cs
@@ -1,0 +1,43 @@
+using System.Collections;
+
+using k8s;
+using k8s.Models;
+
+namespace KubeOps.Operator.Logging;
+
+#pragma warning disable CA1710
+internal sealed record EntityLoggingScope : IReadOnlyCollection<KeyValuePair<string, object>>
+#pragma warning restore CA1710
+{
+    private EntityLoggingScope(IReadOnlyDictionary<string, object> state)
+    {
+        Values = state;
+    }
+
+    public int Count => Values.Count;
+
+    private string? CachedFormattedString { get; set; }
+
+    private IReadOnlyDictionary<string, object> Values { get; }
+
+    public static EntityLoggingScope CreateFor<TEntity>(WatchEventType eventType, TEntity entity)
+        where TEntity : IKubernetesObject<V1ObjectMeta>
+        => new(
+            new Dictionary<string, object>
+            {
+                { "EventType", eventType },
+                { nameof(entity.Kind), entity.Kind },
+                { "Namespace", entity.Namespace() },
+                { "Name", entity.Name() },
+                { "ResourceVersion", entity.ResourceVersion() },
+            });
+
+    public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
+        => Values.GetEnumerator();
+
+    public override string ToString()
+        => CachedFormattedString ??= $"{{ {string.Join(", ", Values.Select(kvp => $"{kvp.Key} = {kvp.Value}"))} }}";
+
+    IEnumerator IEnumerable.GetEnumerator()
+        => GetEnumerator();
+}

--- a/src/KubeOps.Operator/Watcher/ResourceWatcher{TEntity}.cs
+++ b/src/KubeOps.Operator/Watcher/ResourceWatcher{TEntity}.cs
@@ -11,6 +11,7 @@ using KubeOps.Abstractions.Controller;
 using KubeOps.Abstractions.Entities;
 using KubeOps.Abstractions.Finalizer;
 using KubeOps.KubernetesClient;
+using KubeOps.Operator.Logging;
 using KubeOps.Operator.Queue;
 
 using Microsoft.Extensions.DependencyInjection;
@@ -200,17 +201,7 @@ public class ResourceWatcher<TEntity>(
                                    cancellationToken: stoppingToken))
                 {
 #pragma warning disable SA1312
-                    using var _ = logger.BeginScope(new
-#pragma warning restore SA1312
-                    {
-                        EventType = type,
-
-                        // ReSharper disable once RedundantAnonymousTypePropertyName
-                        Kind = entity.Kind,
-                        Namespace = entity.Namespace(),
-                        Name = entity.Name(),
-                        ResourceVersion = entity.ResourceVersion(),
-                    });
+                    using var _ = logger.BeginScope(EntityLoggingScope.CreateFor(type, entity));
                     logger.LogInformation(
                         """Received watch event "{EventType}" for "{Kind}/{Name}", last observed resource version: {ResourceVersion}.""",
                         type,


### PR DESCRIPTION
Hello @buehler,

We’ve noticed that the logging scope isn’t being properly transported to Application Insights. Based on the documentation (https://learn.microsoft.com/en-us/azure/azure-monitor/app/ilogger#logging-scopes), I’ve made a small adjustment so that the scope is passed as key-value pairs into the custom properties of Application Insights. This change should not affect the console output.

> If the scope is of type IReadOnlyCollection<KeyValuePair<string,object>>, then each key/value pair in the collection is added to the Application Insights telemetry as custom properties.

I’ve introduced an EntityLoggingScope that derives from IReadOnlyCollection<KeyValuePair<string, object>>, which is then used accordingly in the BeginScope of the ResourceWatcher:

```csharp
using var _ = logger.BeginScope(EntityLoggingScope.CreateFor(type, entity));
```

Thanks and best regards,
Marcus