### PR TITLE
fix(operator): correct local kubeops CLI detection

### DIFF
--- a/src/KubeOps.Operator/Build/KubeOps.Operator.targets
+++ b/src/KubeOps.Operator/Build/KubeOps.Operator.targets
@@ -40,8 +40,7 @@
             <NoAnsi Condition="'$(KubeOpsNoAnsi)' == 'true' Or '$(KubeOpsIsCI)' == 'true'">--no-ansi</NoAnsi>
         </PropertyGroup>
 
-        <Exec ContinueOnError="true"
-              WorkingDirectory="$(MSBuildProjectDirectory)"
+        <Exec WorkingDirectory="$(MSBuildProjectDirectory)"
               Command="$(KubeOpsCli) generate operator $(NoAnsi) --out $(KubeOpsConfigOut) $(DockerImage) $(DockerImageTag) $(OperatorName) $(MSBuildProjectFullPath)" />
     </Target>
 
@@ -58,7 +57,7 @@
         <Exec Condition="'$(KubeOpsCliSource)' == 'Default' And '$(CliInstalled)' != '0'"
               IgnoreExitCode="true" StandardOutputImportance="low" StandardErrorImportance="low"
               WorkingDirectory="$(MSBuildProjectDirectory)"
-              Command="dotnet tool run kubeops -h">
+              Command="dotnet tool run kubeops -- -h">
             <Output TaskParameter="ExitCode" PropertyName="LocalCliInstalled" />
         </Exec>
 


### PR DESCRIPTION
Addresses dotnet/dotnet-operator-sdk#1030.

## Context
During `dotnet publish`, KubeOps runs `kubeops generate ...` via MSBuild targets. When the global `kubeops` command isn't available (common in Docker/CI), the targets try to detect a local tool fallback.

The local-tool probe currently uses `dotnet tool run kubeops -h`, but `-h` is parsed by `dotnet tool run` itself (help), so it can exit `0` even when there is no tool manifest / no local `kubeops` tool. This false-positive switches `KubeOpsCli` to `dotnet tool run kubeops` and then fails later during generation.

## Change
- Probe the local tool via `dotnet tool run kubeops -- -h` so `-h` is forwarded to `kubeops` and the exit code reflects actual tool availability.
- Keep `kubeops generate ...` failures as errors (no `ContinueOnError`).

## Tested
- Local: verified `dotnet tool run kubeops -h` vs `dotnet tool run kubeops -- -h` semantics and ran a minimal MSBuild repro.
- CI: GitHub Actions on this PR.
