### PR TITLE
feat(controllers): Enable multiple controllers with different label selectors for the same entity type (V2)

### DIFF
--- a/src/KubeOps.Abstractions/Reconciliation/Controller/IEntityController{TEntity}.cs
+++ b/src/KubeOps.Abstractions/Reconciliation/Controller/IEntityController{TEntity}.cs
@@ -41,6 +41,17 @@ public interface IEntityController<TEntity>
     where TEntity : IKubernetesObject<V1ObjectMeta>
 {
     /// <summary>
+    /// An optional Kubernetes label selector expression (e.g. <c>app in (foo,bar),env=prod</c>) that
+    /// restricts which entities this controller handles. When <c>null</c> (the default) the controller
+    /// handles all entities of the given type, preserving backward-compatible behaviour.
+    ///
+    /// When multiple controllers are registered for the same entity type the reconciler evaluates every
+    /// controller's <see cref="LabelFilter"/> against the entity's labels and dispatches to all that
+    /// match, allowing fine-grained fan-out without touching the watcher or DI registration plumbing.
+    /// </summary>
+    string? LabelFilter => null;
+
+    /// <summary>
     /// Reconciles the state of the specified entity with the desired state.
     /// This method is triggered for `added` and `modified` events from the watcher.
     /// </summary>

--- a/src/KubeOps.Abstractions/Reconciliation/Controller/IEntityController{TEntity}.cs
+++ b/src/KubeOps.Abstractions/Reconciliation/Controller/IEntityController{TEntity}.cs
@@ -41,7 +41,7 @@ public interface IEntityController<TEntity>
     where TEntity : IKubernetesObject<V1ObjectMeta>
 {
     /// <summary>
-    /// An optional Kubernetes label selector expression (e.g. <c>app in (foo,bar),env=prod</c>) that
+    /// An optional Kubernetes label selector expression (e.g. <c>app in (foo,bar),env in (prod)</c>) that
     /// restricts which entities this controller handles. When <c>null</c> (the default) the controller
     /// handles all entities of the given type, preserving backward-compatible behaviour.
     ///

--- a/src/KubeOps.Operator/Builder/OperatorBuilder.cs
+++ b/src/KubeOps.Operator/Builder/OperatorBuilder.cs
@@ -46,7 +46,7 @@ internal sealed class OperatorBuilder : IOperatorBuilder
         where TImplementation : class, IEntityController<TEntity>
         where TEntity : IKubernetesObject<V1ObjectMeta>
     {
-        Services.TryAddScoped<IEntityController<TEntity>, TImplementation>();
+        Services.AddScoped<IEntityController<TEntity>, TImplementation>();
         Services.TryAddSingleton<IReconciler<TEntity>, Reconciler<TEntity>>();
 
         // Requeue

--- a/src/KubeOps.Operator/Reconciliation/LabelSelectorMatcher.cs
+++ b/src/KubeOps.Operator/Reconciliation/LabelSelectorMatcher.cs
@@ -22,12 +22,7 @@ internal static class LabelSelectorMatcher
         if (selector is null) return true;
         entityLabels ??= new Dictionary<string, string>();
 
-        foreach (var clause in SplitTopLevel(selector))
-        {
-            if (!MatchClause(clause, entityLabels)) return false;
-        }
-
-        return true;
+        return SplitTopLevel(selector).All(clause => MatchClause(clause, entityLabels));
     }
 
     // Splits "key in (a,b),other notin (c)" at top-level commas only (ignores commas inside parens).
@@ -78,6 +73,24 @@ internal static class LabelSelectorMatcher
             var key = clause[..idx].Trim();
             var values = ParseValues(clause[(idx + notinOp.Length)..^1]);
             return !labels.TryGetValue(key, out var v) || !values.Contains(v);
+        }
+
+        // "key!=value"
+        int neqIdx = clause.IndexOf("!=", StringComparison.Ordinal);
+        if (neqIdx >= 0)
+        {
+            var key = clause[..neqIdx].Trim();
+            var value = clause[(neqIdx + 2)..].Trim();
+            return !labels.TryGetValue(key, out var v) || v != value;
+        }
+
+        // "key=value"
+        int eqIdx = clause.IndexOf('=');
+        if (eqIdx >= 0)
+        {
+            var key = clause[..eqIdx].Trim();
+            var value = clause[(eqIdx + 1)..].Trim();
+            return labels.TryGetValue(key, out var v) && v == value;
         }
 
         // "!key"

--- a/src/KubeOps.Operator/Reconciliation/LabelSelectorMatcher.cs
+++ b/src/KubeOps.Operator/Reconciliation/LabelSelectorMatcher.cs
@@ -1,0 +1,95 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+namespace KubeOps.Operator.Reconciliation;
+
+/// <summary>
+/// Evaluates a Kubernetes label-selector expression against an entity's label dictionary.
+/// Supports the set-based formats emitted by KubeOps.KubernetesClient label-selector types:
+/// <list type="bullet">
+///   <item><c>key in (v1,v2)</c> – EqualsSelector</item>
+///   <item><c>key notin (v1,v2)</c> – NotEqualsSelector</item>
+///   <item><c>key</c> – ExistsSelector</item>
+///   <item><c>!key</c> – NotExistsSelector</item>
+/// </list>
+/// Multiple clauses joined by commas are evaluated as AND.
+/// </summary>
+internal static class LabelSelectorMatcher
+{
+    internal static bool Matches(string? selector, IReadOnlyDictionary<string, string>? entityLabels)
+    {
+        if (selector is null) return true;
+        entityLabels ??= new Dictionary<string, string>();
+
+        foreach (var clause in SplitTopLevel(selector))
+        {
+            if (!MatchClause(clause, entityLabels)) return false;
+        }
+
+        return true;
+    }
+
+    // Splits "key in (a,b),other notin (c)" at top-level commas only (ignores commas inside parens).
+    private static IEnumerable<string> SplitTopLevel(string selector)
+    {
+        int depth = 0, start = 0;
+        for (int i = 0; i < selector.Length; i++)
+        {
+            switch (selector[i])
+            {
+                case '(':
+                    depth++;
+                    break;
+                case ')':
+                    depth--;
+                    break;
+                case ',' when depth == 0:
+                    yield return selector[start..i].Trim();
+                    start = i + 1;
+                    break;
+            }
+        }
+
+        if (start < selector.Length)
+        {
+            yield return selector[start..].Trim();
+        }
+    }
+
+    private static bool MatchClause(string clause, IReadOnlyDictionary<string, string> labels)
+    {
+        const string inOp = " in (";
+        const string notinOp = " notin (";
+
+        // "key in (v1,v2)"
+        int idx = clause.IndexOf(inOp, StringComparison.Ordinal);
+        if (idx >= 0 && clause.EndsWith(')'))
+        {
+            var key = clause[..idx].Trim();
+            var values = ParseValues(clause[(idx + inOp.Length)..^1]);
+            return labels.TryGetValue(key, out var v) && values.Contains(v);
+        }
+
+        // "key notin (v1,v2)"
+        idx = clause.IndexOf(notinOp, StringComparison.Ordinal);
+        if (idx >= 0 && clause.EndsWith(')'))
+        {
+            var key = clause[..idx].Trim();
+            var values = ParseValues(clause[(idx + notinOp.Length)..^1]);
+            return !labels.TryGetValue(key, out var v) || !values.Contains(v);
+        }
+
+        // "!key"
+        if (clause.StartsWith('!'))
+        {
+            return !labels.ContainsKey(clause[1..].Trim());
+        }
+
+        // "key"
+        return labels.ContainsKey(clause);
+    }
+
+    private static HashSet<string> ParseValues(string csv) =>
+        csv.Split(',').Select(v => v.Trim()).ToHashSet(StringComparer.Ordinal);
+}

--- a/src/KubeOps.Operator/Reconciliation/Reconciler.cs
+++ b/src/KubeOps.Operator/Reconciliation/Reconciler.cs
@@ -6,6 +6,7 @@ using k8s;
 using k8s.Models;
 
 using KubeOps.Abstractions.Builder;
+using KubeOps.Abstractions.Entities;
 using KubeOps.Abstractions.Reconciliation;
 using KubeOps.Abstractions.Reconciliation.Controller;
 using KubeOps.Abstractions.Reconciliation.Finalizer;
@@ -115,8 +116,11 @@ internal sealed class Reconciler<TEntity>(
                 cancellationToken);
 
         await using var scope = serviceProvider.CreateAsyncScope();
-        var controller = scope.ServiceProvider.GetRequiredService<IEntityController<TEntity>>();
-        var result = await controller.DeletedAsync(reconciliationContext.Entity, cancellationToken);
+        var result = await DispatchToMatchingControllers(
+            scope.ServiceProvider,
+            reconciliationContext.Entity,
+            (ctrl, entity, ct) => ctrl.DeletedAsync(entity, ct),
+            cancellationToken);
 
         if (result.IsSuccess)
         {
@@ -150,8 +154,50 @@ internal sealed class Reconciler<TEntity>(
             }
         }
 
-        var controller = scope.ServiceProvider.GetRequiredService<IEntityController<TEntity>>();
-        return await controller.ReconcileAsync(entity, cancellationToken);
+        return await DispatchToMatchingControllers(
+            scope.ServiceProvider,
+            entity,
+            (ctrl, e, ct) => ctrl.ReconcileAsync(e, ct),
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Gets all <see cref="IEntityController{TEntity}"/> registrations whose <see cref="IEntityController{TEntity}.LabelFilter"/>
+    /// matches the given entity's labels, then calls <paramref name="operation"/> on each in registration order.
+    /// On the first failure the chain is short-circuited and that failure result is returned.
+    /// If no controller matches, a success result is returned and a warning is logged.
+    /// </summary>
+    private async Task<ReconciliationResult<TEntity>> DispatchToMatchingControllers(
+        IServiceProvider services,
+        TEntity entity,
+        Func<IEntityController<TEntity>, TEntity, CancellationToken, Task<ReconciliationResult<TEntity>>> operation,
+        CancellationToken cancellationToken)
+    {
+        var entityLabels = (IReadOnlyDictionary<string, string>?)entity.Labels()
+            ?? new Dictionary<string, string>();
+
+        var controllers = services
+            .GetServices<IEntityController<TEntity>>()
+            .Where(c => LabelSelectorMatcher.Matches(c.LabelFilter, entityLabels))
+            .ToList();
+
+        if (controllers.Count == 0)
+        {
+            logger.LogWarning(
+                """No controller matched labels for "{Kind}/{Name}". Skipping.""",
+                entity.Kind,
+                entity.Name());
+            return ReconciliationResult<TEntity>.Success(entity);
+        }
+
+        ReconciliationResult<TEntity> result = ReconciliationResult<TEntity>.Success(entity);
+        foreach (var controller in controllers)
+        {
+            result = await operation(controller, result.Entity, cancellationToken);
+            if (!result.IsSuccess) return result;
+        }
+
+        return result;
     }
 
     private async Task<ReconciliationResult<TEntity>> ReconcileFinalizersSequential(TEntity entity, CancellationToken cancellationToken)

--- a/test/KubeOps.Operator.Test/Builder/OperatorBuilder.Test.cs
+++ b/test/KubeOps.Operator.Test/Builder/OperatorBuilder.Test.cs
@@ -128,6 +128,53 @@ public sealed class OperatorBuilderTest
     }
 
     [Fact]
+    public void Should_Allow_Multiple_Controllers_For_Same_Entity_Type()
+    {
+        _builder.AddController<TestController, V1OperatorIntegrationTestEntity>();
+        _builder.AddController<SecondTestController, V1OperatorIntegrationTestEntity>();
+
+        var registrations = _builder.Services
+            .Where(s =>
+                s.ServiceType == typeof(IEntityController<V1OperatorIntegrationTestEntity>) &&
+                s.Lifetime == ServiceLifetime.Scoped)
+            .ToList();
+
+        registrations.Should().HaveCount(2);
+        registrations.Should().Contain(s => s.ImplementationType == typeof(TestController));
+        registrations.Should().Contain(s => s.ImplementationType == typeof(SecondTestController));
+    }
+
+    [Fact]
+    public void Should_Resolve_All_Controllers_For_Same_Entity_Type()
+    {
+        _builder.AddController<TestController, V1OperatorIntegrationTestEntity>();
+        _builder.AddController<SecondTestController, V1OperatorIntegrationTestEntity>();
+
+        var provider = _builder.Services.BuildServiceProvider();
+        var controllers = provider
+            .GetServices<IEntityController<V1OperatorIntegrationTestEntity>>()
+            .ToList();
+
+        controllers.Should().HaveCount(2);
+        controllers.Should().ContainItemsAssignableTo<IEntityController<V1OperatorIntegrationTestEntity>>();
+        controllers.Select(c => c.GetType()).Should().Contain(typeof(TestController));
+        controllers.Select(c => c.GetType()).Should().Contain(typeof(SecondTestController));
+    }
+
+    [Fact]
+    public void Should_Not_Register_Duplicate_ResourceWatcher_For_Multiple_Controllers()
+    {
+        _builder.AddController<TestController, V1OperatorIntegrationTestEntity>();
+        _builder.AddController<SecondTestController, V1OperatorIntegrationTestEntity>();
+
+        _builder.Services
+            .Where(s =>
+                s.ServiceType == typeof(IHostedService) &&
+                s.ImplementationType == typeof(ResourceWatcher<V1OperatorIntegrationTestEntity>))
+            .Should().HaveCount(1);
+    }
+
+    [Fact]
     public void Should_Add_LeaderAwareResourceWatcher()
     {
         var builder = new OperatorBuilder(new ServiceCollection(), new() { LeaderElectionType = LeaderElectionType.Single });
@@ -144,6 +191,15 @@ public sealed class OperatorBuilderTest
     }
 
     private sealed class TestController : IEntityController<V1OperatorIntegrationTestEntity>
+    {
+        public Task<ReconciliationResult<V1OperatorIntegrationTestEntity>> ReconcileAsync(V1OperatorIntegrationTestEntity entity, CancellationToken cancellationToken) =>
+            Task.FromResult(ReconciliationResult<V1OperatorIntegrationTestEntity>.Success(entity));
+
+        public Task<ReconciliationResult<V1OperatorIntegrationTestEntity>> DeletedAsync(V1OperatorIntegrationTestEntity entity, CancellationToken cancellationToken) =>
+            Task.FromResult(ReconciliationResult<V1OperatorIntegrationTestEntity>.Success(entity));
+    }
+
+    private sealed class SecondTestController : IEntityController<V1OperatorIntegrationTestEntity>
     {
         public Task<ReconciliationResult<V1OperatorIntegrationTestEntity>> ReconcileAsync(V1OperatorIntegrationTestEntity entity, CancellationToken cancellationToken) =>
             Task.FromResult(ReconciliationResult<V1OperatorIntegrationTestEntity>.Success(entity));

--- a/test/KubeOps.Operator.Test/Reconciliation/LabelSelectorMatcher.Test.cs
+++ b/test/KubeOps.Operator.Test/Reconciliation/LabelSelectorMatcher.Test.cs
@@ -193,4 +193,60 @@ public sealed class LabelSelectorMatcherTest
         // key absent → not in any set → true
         LabelSelectorMatcher.Matches("env notin (prod)", new Dictionary<string, string>()).Should().BeTrue();
     }
+
+    // ── key=value equality ────────────────────────────────────────────────────
+
+    [Fact]
+    public void Matches_EqualityOperator_Matches_ReturnsTrue()
+    {
+        var labels = new Dictionary<string, string> { ["env"] = "prod" };
+        LabelSelectorMatcher.Matches("env=prod", labels).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Matches_EqualityOperator_WrongValue_ReturnsFalse()
+    {
+        var labels = new Dictionary<string, string> { ["env"] = "staging" };
+        LabelSelectorMatcher.Matches("env=prod", labels).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Matches_EqualityOperator_KeyAbsent_ReturnsFalse()
+    {
+        LabelSelectorMatcher.Matches("env=prod", new Dictionary<string, string>()).Should().BeFalse();
+    }
+
+    // ── key!=value inequality ─────────────────────────────────────────────────
+
+    [Fact]
+    public void Matches_InequalityOperator_DifferentValue_ReturnsTrue()
+    {
+        var labels = new Dictionary<string, string> { ["env"] = "staging" };
+        LabelSelectorMatcher.Matches("env!=prod", labels).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Matches_InequalityOperator_SameValue_ReturnsFalse()
+    {
+        var labels = new Dictionary<string, string> { ["env"] = "prod" };
+        LabelSelectorMatcher.Matches("env!=prod", labels).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Matches_InequalityOperator_KeyAbsent_ReturnsTrue()
+    {
+        // key absent → not equal → true
+        LabelSelectorMatcher.Matches("env!=prod", new Dictionary<string, string>()).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Matches_MixedEqualityAndSetBased_AllMatch_ReturnsTrue()
+    {
+        var labels = new Dictionary<string, string>
+        {
+            ["env"] = "prod",
+            ["region"] = "eu-west",
+        };
+        LabelSelectorMatcher.Matches("env=prod,region in (eu-west,us-east)", labels).Should().BeTrue();
+    }
 }

--- a/test/KubeOps.Operator.Test/Reconciliation/LabelSelectorMatcher.Test.cs
+++ b/test/KubeOps.Operator.Test/Reconciliation/LabelSelectorMatcher.Test.cs
@@ -1,0 +1,196 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using FluentAssertions;
+
+using KubeOps.Operator.Reconciliation;
+
+namespace KubeOps.Operator.Test.Reconciliation;
+
+public sealed class LabelSelectorMatcherTest
+{
+    // ── null selector ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Matches_NullSelector_ReturnsTrue()
+    {
+        var labels = new Dictionary<string, string> { ["env"] = "prod" };
+        LabelSelectorMatcher.Matches(null, labels).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Matches_NullSelector_EmptyLabels_ReturnsTrue()
+    {
+        LabelSelectorMatcher.Matches(null, new Dictionary<string, string>()).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Matches_NullSelector_NullLabels_ReturnsTrue()
+    {
+        LabelSelectorMatcher.Matches(null, null).Should().BeTrue();
+    }
+
+    // ── "key in (v1,v2)" ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void Matches_InOperator_KeyPresentWithMatchingValue_ReturnsTrue()
+    {
+        var labels = new Dictionary<string, string> { ["env"] = "prod" };
+        LabelSelectorMatcher.Matches("env in (prod)", labels).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Matches_InOperator_KeyPresentAmongMultipleValues_ReturnsTrue()
+    {
+        var labels = new Dictionary<string, string> { ["env"] = "staging" };
+        LabelSelectorMatcher.Matches("env in (prod,staging,dev)", labels).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Matches_InOperator_KeyPresentButWrongValue_ReturnsFalse()
+    {
+        var labels = new Dictionary<string, string> { ["env"] = "dev" };
+        LabelSelectorMatcher.Matches("env in (prod,staging)", labels).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Matches_InOperator_KeyAbsent_ReturnsFalse()
+    {
+        var labels = new Dictionary<string, string> { ["tier"] = "frontend" };
+        LabelSelectorMatcher.Matches("env in (prod)", labels).Should().BeFalse();
+    }
+
+    // ── "key notin (v1,v2)" ──────────────────────────────────────────────────
+
+    [Fact]
+    public void Matches_NotInOperator_KeyAbsent_ReturnsTrue()
+    {
+        var labels = new Dictionary<string, string> { ["tier"] = "frontend" };
+        LabelSelectorMatcher.Matches("env notin (prod)", labels).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Matches_NotInOperator_KeyPresentButNotInValues_ReturnsTrue()
+    {
+        var labels = new Dictionary<string, string> { ["env"] = "dev" };
+        LabelSelectorMatcher.Matches("env notin (prod,staging)", labels).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Matches_NotInOperator_KeyPresentAndInValues_ReturnsFalse()
+    {
+        var labels = new Dictionary<string, string> { ["env"] = "prod" };
+        LabelSelectorMatcher.Matches("env notin (prod,staging)", labels).Should().BeFalse();
+    }
+
+    // ── "key" (exists) ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Matches_ExistsOperator_KeyPresent_ReturnsTrue()
+    {
+        var labels = new Dictionary<string, string> { ["managed"] = "true" };
+        LabelSelectorMatcher.Matches("managed", labels).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Matches_ExistsOperator_KeyAbsent_ReturnsFalse()
+    {
+        var labels = new Dictionary<string, string> { ["env"] = "prod" };
+        LabelSelectorMatcher.Matches("managed", labels).Should().BeFalse();
+    }
+
+    // ── "!key" (not exists) ───────────────────────────────────────────────────
+
+    [Fact]
+    public void Matches_NotExistsOperator_KeyAbsent_ReturnsTrue()
+    {
+        var labels = new Dictionary<string, string> { ["env"] = "prod" };
+        LabelSelectorMatcher.Matches("!managed", labels).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Matches_NotExistsOperator_KeyPresent_ReturnsFalse()
+    {
+        var labels = new Dictionary<string, string> { ["managed"] = "true" };
+        LabelSelectorMatcher.Matches("!managed", labels).Should().BeFalse();
+    }
+
+    // ── multi-clause (AND semantics) ─────────────────────────────────────────
+
+    [Fact]
+    public void Matches_MultiClause_AllMatch_ReturnsTrue()
+    {
+        var labels = new Dictionary<string, string>
+        {
+            ["env"] = "prod",
+            ["managed"] = "true",
+        };
+        LabelSelectorMatcher.Matches("env in (prod),managed in (true)", labels).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Matches_MultiClause_OneClauseDoesNotMatch_ReturnsFalse()
+    {
+        var labels = new Dictionary<string, string>
+        {
+            ["env"] = "prod",
+            ["managed"] = "false",
+        };
+        LabelSelectorMatcher.Matches("env in (prod),managed in (true)", labels).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Matches_MultiClause_InAndNotIn_ReturnsTrue()
+    {
+        var labels = new Dictionary<string, string>
+        {
+            ["env"] = "prod",
+        };
+        LabelSelectorMatcher.Matches("env in (prod),!managed", labels).Should().BeTrue();
+    }
+
+    // ── commas inside parentheses must NOT be treated as clause separators ───
+
+    [Fact]
+    public void Matches_InOperatorWithCommaInValues_DoesNotSplitAtInnerComma()
+    {
+        // "env in (prod,staging)" has a comma inside parens — must be treated as ONE clause
+        var labels = new Dictionary<string, string> { ["env"] = "staging" };
+        LabelSelectorMatcher.Matches("env in (prod,staging)", labels).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Matches_ComplexMultiClauseWithCommaInsideParens_CorrectlyEvaluated()
+    {
+        var labels = new Dictionary<string, string>
+        {
+            ["env"] = "prod",
+            ["region"] = "eu-west",
+        };
+        LabelSelectorMatcher.Matches(
+            "env in (prod,staging),region notin (us-east,us-west)",
+            labels).Should().BeTrue();
+    }
+
+    // ── empty labels ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Matches_ExistsClause_EmptyLabels_ReturnsFalse()
+    {
+        LabelSelectorMatcher.Matches("env", new Dictionary<string, string>()).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Matches_NotExistsClause_EmptyLabels_ReturnsTrue()
+    {
+        LabelSelectorMatcher.Matches("!env", new Dictionary<string, string>()).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Matches_NotInClause_EmptyLabels_ReturnsTrue()
+    {
+        // key absent → not in any set → true
+        LabelSelectorMatcher.Matches("env notin (prod)", new Dictionary<string, string>()).Should().BeTrue();
+    }
+}

--- a/test/KubeOps.Operator.Test/Reconciliation/Reconciler.MultiController.Test.cs
+++ b/test/KubeOps.Operator.Test/Reconciliation/Reconciler.MultiController.Test.cs
@@ -1,0 +1,310 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using FluentAssertions;
+
+using k8s;
+using k8s.Models;
+
+using KubeOps.Abstractions.Builder;
+using KubeOps.Abstractions.Reconciliation;
+using KubeOps.Abstractions.Reconciliation.Controller;
+using KubeOps.KubernetesClient;
+using KubeOps.Operator.Queue;
+using KubeOps.Operator.Reconciliation;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+using Moq;
+
+using ZiggyCreatures.Caching.Fusion;
+
+namespace KubeOps.Operator.Test.Reconciliation;
+
+/// <summary>
+/// Tests for the multi-controller dispatch logic in <see cref="Reconciler{TEntity}"/>.
+/// Verifies that <see cref="IEntityController{TEntity}.LabelFilter"/> is respected when
+/// multiple controllers are registered for the same entity type.
+/// </summary>
+public sealed class ReconcilerMultiControllerTest
+{
+    private readonly Mock<ILogger<Reconciler<V1ConfigMap>>> _mockLogger = new();
+    private readonly Mock<IFusionCacheProvider> _mockCacheProvider = new();
+    private readonly Mock<IFusionCache> _mockCache = new();
+    private readonly Mock<IKeyedServiceProvider> _mockServiceProvider = new();
+    private readonly Mock<IKubernetesClient> _mockClient = new();
+    private readonly Mock<ITimedEntityQueue<V1ConfigMap>> _mockQueue = new();
+    private readonly OperatorSettings _settings = new() { AutoAttachFinalizers = false, AutoDetachFinalizers = false };
+
+    public ReconcilerMultiControllerTest()
+    {
+        _mockCacheProvider
+            .Setup(p => p.GetCache(It.IsAny<string>()))
+            .Returns(_mockCache.Object);
+    }
+
+    // ── null LabelFilter = catch-all ──────────────────────────────────────────
+
+    [Fact]
+    public async Task Dispatch_NullLabelFilter_MatchesEntityWithNoLabels()
+    {
+        var entity = CreateEntity();
+        var controller = CreateController(labelFilter: null);
+        var reconciler = CreateReconciler([controller.Object]);
+
+        var context = ReconciliationContext<V1ConfigMap>.CreateFromApiServerEvent(entity, WatchEventType.Added);
+        await reconciler.Reconcile(context, TestContext.Current.CancellationToken);
+
+        controller.Verify(c => c.ReconcileAsync(entity, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Dispatch_NullLabelFilter_MatchesEntityWithLabels()
+    {
+        var entity = CreateEntity(labels: new() { ["env"] = "prod" });
+        var controller = CreateController(labelFilter: null);
+        var reconciler = CreateReconciler([controller.Object]);
+
+        var context = ReconciliationContext<V1ConfigMap>.CreateFromApiServerEvent(entity, WatchEventType.Added);
+        await reconciler.Reconcile(context, TestContext.Current.CancellationToken);
+
+        controller.Verify(c => c.ReconcileAsync(entity, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    // ── label filter matching ─────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Dispatch_LabelFilterMatches_ControllerIsCalled()
+    {
+        var entity = CreateEntity(labels: new() { ["env"] = "prod" });
+        var controller = CreateController(labelFilter: "env in (prod)");
+        var reconciler = CreateReconciler([controller.Object]);
+
+        var context = ReconciliationContext<V1ConfigMap>.CreateFromApiServerEvent(entity, WatchEventType.Added);
+        await reconciler.Reconcile(context, TestContext.Current.CancellationToken);
+
+        controller.Verify(c => c.ReconcileAsync(entity, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Dispatch_LabelFilterDoesNotMatch_ControllerIsNotCalled()
+    {
+        var entity = CreateEntity(labels: new() { ["env"] = "staging" });
+        var controller = CreateController(labelFilter: "env in (prod)");
+        var reconciler = CreateReconciler([controller.Object]);
+
+        var context = ReconciliationContext<V1ConfigMap>.CreateFromApiServerEvent(entity, WatchEventType.Added);
+        await reconciler.Reconcile(context, TestContext.Current.CancellationToken);
+
+        controller.Verify(c => c.ReconcileAsync(It.IsAny<V1ConfigMap>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Dispatch_EntityHasNoLabels_FilteredControllerIsNotCalled()
+    {
+        var entity = CreateEntity();
+        var controller = CreateController(labelFilter: "env in (prod)");
+        var reconciler = CreateReconciler([controller.Object]);
+
+        var context = ReconciliationContext<V1ConfigMap>.CreateFromApiServerEvent(entity, WatchEventType.Added);
+        await reconciler.Reconcile(context, TestContext.Current.CancellationToken);
+
+        controller.Verify(c => c.ReconcileAsync(It.IsAny<V1ConfigMap>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // ── multiple controllers ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Dispatch_TwoMatchingControllers_BothCalledInOrder()
+    {
+        var entity = CreateEntity(labels: new() { ["env"] = "prod" });
+        var callOrder = new List<int>();
+
+        var ctrl1 = CreateController(labelFilter: "env in (prod)", onReconcile: e =>
+        {
+            callOrder.Add(1);
+            return ReconciliationResult<V1ConfigMap>.Success(e);
+        });
+        var ctrl2 = CreateController(labelFilter: null, onReconcile: e =>
+        {
+            callOrder.Add(2);
+            return ReconciliationResult<V1ConfigMap>.Success(e);
+        });
+
+        var reconciler = CreateReconciler([ctrl1.Object, ctrl2.Object]);
+        var context = ReconciliationContext<V1ConfigMap>.CreateFromApiServerEvent(entity, WatchEventType.Added);
+        await reconciler.Reconcile(context, TestContext.Current.CancellationToken);
+
+        callOrder.Should().Equal(1, 2);
+    }
+
+    [Fact]
+    public async Task Dispatch_TwoControllers_OnlyMatchingOneIsCalled()
+    {
+        var entity = CreateEntity(labels: new() { ["env"] = "prod" });
+        var prodCtrl = CreateController(labelFilter: "env in (prod)");
+        var stagingCtrl = CreateController(labelFilter: "env in (staging)");
+
+        var reconciler = CreateReconciler([prodCtrl.Object, stagingCtrl.Object]);
+        var context = ReconciliationContext<V1ConfigMap>.CreateFromApiServerEvent(entity, WatchEventType.Added);
+        await reconciler.Reconcile(context, TestContext.Current.CancellationToken);
+
+        prodCtrl.Verify(c => c.ReconcileAsync(entity, It.IsAny<CancellationToken>()), Times.Once);
+        stagingCtrl.Verify(c => c.ReconcileAsync(It.IsAny<V1ConfigMap>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Dispatch_FirstControllerFails_SecondControllerNotCalled()
+    {
+        var entity = CreateEntity(labels: new() { ["env"] = "prod" });
+        var failResult = ReconciliationResult<V1ConfigMap>.Failure(entity, "first failed");
+
+        var ctrl1 = CreateController(labelFilter: null, onReconcile: _ => failResult);
+        var ctrl2 = CreateController(labelFilter: null);
+
+        var reconciler = CreateReconciler([ctrl1.Object, ctrl2.Object]);
+        var context = ReconciliationContext<V1ConfigMap>.CreateFromApiServerEvent(entity, WatchEventType.Added);
+        var result = await reconciler.Reconcile(context, TestContext.Current.CancellationToken);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorMessage.Should().Be("first failed");
+        ctrl2.Verify(c => c.ReconcileAsync(It.IsAny<V1ConfigMap>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Dispatch_NoControllerMatches_ReturnsSuccess()
+    {
+        var entity = CreateEntity(labels: new() { ["env"] = "prod" });
+        var controller = CreateController(labelFilter: "env in (staging)");
+
+        var reconciler = CreateReconciler([controller.Object]);
+        var context = ReconciliationContext<V1ConfigMap>.CreateFromApiServerEvent(entity, WatchEventType.Added);
+        var result = await reconciler.Reconcile(context, TestContext.Current.CancellationToken);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Dispatch_NoControllerMatches_LogsWarning()
+    {
+        var entity = CreateEntity(labels: new() { ["env"] = "prod" });
+        var controller = CreateController(labelFilter: "env in (staging)");
+
+        var reconciler = CreateReconciler([controller.Object]);
+        var context = ReconciliationContext<V1ConfigMap>.CreateFromApiServerEvent(entity, WatchEventType.Added);
+        await reconciler.Reconcile(context, TestContext.Current.CancellationToken);
+
+        _mockLogger.Verify(l => l.Log(
+            LogLevel.Warning,
+            It.IsAny<EventId>(),
+            It.Is<It.IsAnyType>((o, _) => o.ToString()!.Contains(entity.Name())),
+            null,
+            It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    // ── entity is passed through the chain ────────────────────────────────────
+
+    [Fact]
+    public async Task Dispatch_ControllerMutatesEntity_NextControllerReceivesMutatedEntity()
+    {
+        var original = CreateEntity();
+        var mutated = CreateEntity(name: "mutated-configmap");
+
+        var ctrl1 = CreateController(labelFilter: null, onReconcile: _ =>
+            ReconciliationResult<V1ConfigMap>.Success(mutated));
+
+        V1ConfigMap? receivedByCtrl2 = null;
+        var ctrl2 = CreateController(labelFilter: null, onReconcile: e =>
+        {
+            receivedByCtrl2 = e;
+            return ReconciliationResult<V1ConfigMap>.Success(e);
+        });
+
+        var reconciler = CreateReconciler([ctrl1.Object, ctrl2.Object]);
+        var context = ReconciliationContext<V1ConfigMap>.CreateFromApiServerEvent(original, WatchEventType.Added);
+        await reconciler.Reconcile(context, TestContext.Current.CancellationToken);
+
+        receivedByCtrl2.Should().BeSameAs(mutated);
+    }
+
+    // ── DeletedAsync path ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Dispatch_DeletedEvent_MatchingControllerDeletedAsyncCalled()
+    {
+        var entity = CreateEntity(labels: new() { ["env"] = "prod" });
+        var controller = CreateController(labelFilter: "env in (prod)");
+
+        var reconciler = CreateReconciler([controller.Object]);
+        var context = ReconciliationContext<V1ConfigMap>.CreateFromApiServerEvent(entity, WatchEventType.Deleted);
+        await reconciler.Reconcile(context, TestContext.Current.CancellationToken);
+
+        controller.Verify(c => c.DeletedAsync(entity, It.IsAny<CancellationToken>()), Times.Once);
+        controller.Verify(c => c.ReconcileAsync(It.IsAny<V1ConfigMap>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private Reconciler<V1ConfigMap> CreateReconciler(IList<IEntityController<V1ConfigMap>> controllers)
+    {
+        var mockScope = new Mock<IServiceScope>();
+        var mockScopeFactory = new Mock<IServiceScopeFactory>();
+
+        mockScope.Setup(s => s.ServiceProvider).Returns(_mockServiceProvider.Object);
+        mockScopeFactory.Setup(s => s.CreateScope()).Returns(mockScope.Object);
+
+        _mockServiceProvider
+            .Setup(p => p.GetService(typeof(IServiceScopeFactory)))
+            .Returns(mockScopeFactory.Object);
+
+        _mockServiceProvider
+            .Setup(p => p.GetService(typeof(IEnumerable<IEntityController<V1ConfigMap>>)))
+            .Returns(controllers);
+
+        return new(
+            _mockLogger.Object,
+            _mockCacheProvider.Object,
+            _mockServiceProvider.Object,
+            _settings,
+            _mockQueue.Object,
+            _mockClient.Object);
+    }
+
+    private static Mock<IEntityController<V1ConfigMap>> CreateController(
+        string? labelFilter,
+        Func<V1ConfigMap, ReconciliationResult<V1ConfigMap>>? onReconcile = null)
+    {
+        var mock = new Mock<IEntityController<V1ConfigMap>>();
+
+        mock.Setup(c => c.LabelFilter).Returns(labelFilter);
+
+        mock.Setup(c => c.ReconcileAsync(It.IsAny<V1ConfigMap>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((V1ConfigMap e, CancellationToken _) =>
+                onReconcile?.Invoke(e) ?? ReconciliationResult<V1ConfigMap>.Success(e));
+
+        mock.Setup(c => c.DeletedAsync(It.IsAny<V1ConfigMap>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((V1ConfigMap e, CancellationToken _) =>
+                ReconciliationResult<V1ConfigMap>.Success(e));
+
+        return mock;
+    }
+
+    private static V1ConfigMap CreateEntity(
+        string? name = null,
+        Dictionary<string, string>? labels = null) =>
+        new()
+        {
+            Metadata = new()
+            {
+                Name = name ?? "test-configmap",
+                NamespaceProperty = "default",
+                Uid = Guid.NewGuid().ToString(),
+                Generation = 1,
+                Labels = labels,
+            },
+            Kind = V1ConfigMap.KubeKind,
+        };
+}

--- a/test/KubeOps.Operator.Test/Reconciliation/Reconciler.Test.cs
+++ b/test/KubeOps.Operator.Test/Reconciliation/Reconciler.Test.cs
@@ -471,8 +471,8 @@ public sealed class ReconcilerTest
             .Returns(mockScopeFactory.Object);
 
         _mockServiceProvider
-            .Setup(p => p.GetService(typeof(IEntityController<V1ConfigMap>)))
-            .Returns(controller);
+            .Setup(p => p.GetService(typeof(IEnumerable<IEntityController<V1ConfigMap>>)))
+            .Returns(new List<IEntityController<V1ConfigMap>> { controller });
 
         return new(
             _mockLogger.Object,


### PR DESCRIPTION
## Multi-controller dispatch via `LabelFilter` on `IEntityController<TEntity>`

Fixes #909. A continuation of #911 

## Overview

Adds support for registering multiple controllers for the same Kubernetes entity type, each handling a different subset of resources based on label selectors. The implementation follows the approach requested in review: a single property on the existing interface, runtime dispatch, and no breaking changes.

## Changes

### `IEntityController<TEntity>` — one new default property

```csharp
// Default: null = catch-all (matches all entities, preserves existing behaviour)
string? LabelFilter { get; } => null;
```

Controllers that need to scope themselves declare a selector expression:

```csharp
public string? LabelFilter =>
    new LabelSelector[] { new EqualsSelector("env", "prod") }.ToExpression();
```

### `OperatorBuilder` — `AddScoped` instead of `TryAddScoped`

One line change. `TryAddScoped` silently drops duplicate service registrations; `AddScoped` appends them, enabling `GetServices<IEntityController<TEntity>>()` to resolve all registered controllers for an entity type.

### `Reconciler<TEntity>` — dispatch to all matching controllers

New `DispatchToMatchingControllers` method replaces the single `GetRequiredService` call. It resolves all registered controllers, filters by `LabelFilter` against the entity's labels, and calls each matching one in registration order. On the first failure the chain short-circuits.

### `LabelSelectorMatcher` — new internal utility

Evaluates KubeOps set-based selector expressions (`key in (v1,v2)`, `key notin (v1,v2)`, `key`, `!key`) against an entity's label dictionary at runtime. Handles multi-clause AND semantics and ignores commas inside parentheses.

## What was explicitly NOT changed

- `IEntityLabelSelector<TEntity>` — untouched
- `ResourceWatcher<TEntity>` — untouched; one watcher per entity type regardless of controller count
- `AddController<TImplementation, TEntity>()` signature — unchanged
- All existing controller implementations — work without modification

## Tests

- **`LabelSelectorMatcher.Test.cs`** — 22 unit tests covering all 4 selector operators, multi-clause AND, inner-comma handling, empty/null labels
- **`Reconciler.MultiController.Test.cs`** — 12 tests: catch-all null filter, label match/no-match, ordering, failure short-circuit, entity mutation pass-through, `DeletedAsync` path
- **`OperatorBuilder.Test.cs`** — 3 new tests: multiple registrations in service collection, runtime `GetServices` resolution, no duplicate `ResourceWatcher` registered
- **Fixed** existing `Reconciler.Test.cs` mock: updated from `GetService(IEntityController<T>)` to `GetService(IEnumerable<IEntityController<T>>)` to match the new dispatch path

## Example

```csharp
// Register multiple controllers for the same entity type
builder.AddController<ProdController, MyEntity>();   // LabelFilter => "env in (prod)"
builder.AddController<DevController, MyEntity>();    // LabelFilter => "env in (dev)"
builder.AddController<AuditController, MyEntity>();  // LabelFilter => null (all entities)
```

## Backward compatibility

A controller with no `LabelFilter` override returns `null`, which matches every entity — identical to existing behaviour. No existing code requires changes.
