### PR TITLE
Fix reference to code of conduct.

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,6 @@
 # Code of Conduct
 
-This project adheres to the .NET Foundation's Code of Conduct.
-For more details, please see the full text at:
-https://dotnetfoundation.org/about/policies/code-of-conduct
+This project has adopted the code of conduct defined by the Contributor Covenant
+to clarify expected behavior in our community.
+
+For more information, see the [.NET Foundation Code of Conduct](https://dotnetfoundation.org/code-of-conduct).


### PR DESCRIPTION
See dotnet/org-policy-violations#7160

Fixes violation of policy [PR16](https://github.com/dotnet/org-policy/blob/main/doc/PR16.md), by updating the link to the code of conduct.